### PR TITLE
Add MCP server + semantic searching

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "gmodwiki",
+  "owner": {
+    "name": "CFC-Servers",
+    "url": "https://github.com/CFC-Servers"
+  },
+  "plugins": [
+    {
+      "name": "gmodwiki",
+      "source": "./semantic/mcp/plugin",
+      "description": "Semantic search over the Garry's Mod Lua API wiki (gmodwiki.com) via MCP — adds search_wiki and get_page tools."
+    }
+  ]
+}

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -1,0 +1,46 @@
+name: Deploy MCP Server
+
+# The hosted MCP worker is CODE, not content. It reads the Vectorize index at
+# runtime, so new embeddings (produced by update.yml / full_update.yml) go live
+# without a redeploy. The worker only needs deploying when its own code changes
+# — hence this is push-triggered and path-scoped, NOT on the content cron.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'semantic/mcp/hosted/**'
+      - 'semantic/core/**'
+      - 'semantic/adapters/hosted/**'
+      - '.github/workflows/deploy-mcp.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "npm"
+
+      # Root deps provide `zod` (pulled into the bundle by semantic/core/tools.ts);
+      # the worker's own deps (agents, @modelcontextprotocol/sdk, wrangler) come
+      # from its package. esbuild resolves each import from the file's location up.
+      - name: Install dependencies
+        run: |
+          npm --no-audit --progress=false ci
+          npm --no-audit --progress=false --prefix semantic/mcp/hosted ci
+
+      - name: Test
+        run: npm test
+
+      - name: Deploy worker
+        working-directory: semantic/mcp/hosted
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: npx wrangler deploy

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -1,9 +1,5 @@
 name: Deploy MCP Server
 
-# The hosted MCP worker is CODE, not content. It reads the Vectorize index at
-# runtime, so new embeddings (produced by update.yml / full_update.yml) go live
-# without a redeploy. The worker only needs deploying when its own code changes
-# — hence this is push-triggered and path-scoped, NOT on the content cron.
 on:
   push:
     branches: [main]
@@ -27,9 +23,6 @@ jobs:
           node-version: 24
           cache: "npm"
 
-      # Root deps provide `zod` (pulled into the bundle by semantic/core/tools.ts);
-      # the worker's own deps (agents, @modelcontextprotocol/sdk, wrangler) come
-      # from its package. esbuild resolves each import from the file's location up.
       - name: Install dependencies
         run: |
           npm --no-audit --progress=false ci

--- a/.github/workflows/full_update.yml
+++ b/.github/workflows/full_update.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Scrape and Build
         env:
           BUILD_ENV: production
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_AI_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
         run: |
           npm run build
 
@@ -44,6 +46,10 @@ jobs:
           # Temporarily move it out of the public dir to keep it out of the Cloudflare bundle
           # (it's too big, we upload it to R2 but include it in the docker image)
           mv --verbose ./public/search_index.json .
+          # Embeddings artifact gets the same treatment: kept out of the Cloudflare deploy,
+          # shipped via R2 + docker. Guarded in case embeddings weren't generated (no creds).
+          if [ -f ./public/embeddings.bin ]; then mv --verbose ./public/embeddings.bin .; fi
+          if [ -f ./public/embeddings_manifest.json ]; then mv --verbose ./public/embeddings_manifest.json .; fi
           npm run astrobuild
 
 
@@ -63,7 +69,20 @@ jobs:
           (npx wrangler r2 object put gmodwiki/public_cache.zip --remote --file ./public_cache.zip && rm -v public_cache.zip) &
           (npx wrangler r2 object put gmodwiki/build_cache.zip --remote --file ./build_cache.zip && rm -v build_cache.zip) &
           (npx wrangler r2 object put gmodwiki/search_index.json --remote --file ./search_index.json && mv ./search_index.json ./public/) &
+          ([ -f ./embeddings.bin ] && npx wrangler r2 object put gmodwiki/embeddings.bin --remote --file ./embeddings.bin && mv ./embeddings.bin ./public/) &
+          ([ -f ./embeddings_manifest.json ] && npx wrangler r2 object put gmodwiki/embeddings_manifest.json --remote --file ./embeddings_manifest.json && mv ./embeddings_manifest.json ./public/) &
           wait
+
+      - name: Sync embeddings into Vectorize
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_AI_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: |
+          if [ -f ./public/embeddings.bin ]; then
+            npm run vectorize_sync
+          else
+            echo "no embeddings artifact present; skipping Vectorize sync"
+          fi
 
       # CF Publish
       - name: Publish Site

--- a/.github/workflows/full_update.yml
+++ b/.github/workflows/full_update.yml
@@ -46,8 +46,6 @@ jobs:
           # Temporarily move it out of the public dir to keep it out of the Cloudflare bundle
           # (it's too big, we upload it to R2 but include it in the docker image)
           mv --verbose ./public/search_index.json .
-          # Embeddings artifact gets the same treatment: kept out of the Cloudflare deploy,
-          # shipped via R2 + docker. Guarded in case embeddings weren't generated (no creds).
           if [ -f ./public/embeddings.bin ]; then mv --verbose ./public/embeddings.bin .; fi
           if [ -f ./public/embeddings_manifest.json ]; then mv --verbose ./public/embeddings_manifest.json .; fi
           npm run astrobuild

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,8 +48,6 @@ jobs:
           # Temporarily move it out of the public dir to keep it out of the Cloudflare bundle
           # (it's too big, we upload it to R2 but include it in the docker image)
           mv --verbose ./public/search_index.json .
-          # Embeddings artifact gets the same treatment: kept out of the Cloudflare deploy,
-          # shipped via R2 + docker. Guarded in case embeddings weren't generated (no creds).
           if [ -f ./public/embeddings.bin ]; then mv --verbose ./public/embeddings.bin .; fi
           if [ -f ./public/embeddings_manifest.json ]; then mv --verbose ./public/embeddings_manifest.json .; fi
           npm run astrobuild

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Scrape and Build
         env:
           BUILD_ENV: production
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_AI_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
         run: |
           npm run build
 
@@ -46,6 +48,10 @@ jobs:
           # Temporarily move it out of the public dir to keep it out of the Cloudflare bundle
           # (it's too big, we upload it to R2 but include it in the docker image)
           mv --verbose ./public/search_index.json .
+          # Embeddings artifact gets the same treatment: kept out of the Cloudflare deploy,
+          # shipped via R2 + docker. Guarded in case embeddings weren't generated (no creds).
+          if [ -f ./public/embeddings.bin ]; then mv --verbose ./public/embeddings.bin .; fi
+          if [ -f ./public/embeddings_manifest.json ]; then mv --verbose ./public/embeddings_manifest.json .; fi
           npm run astrobuild
 
 
@@ -65,7 +71,20 @@ jobs:
           (npx wrangler r2 object put gmodwiki/public_cache.zip --remote --file ./public_cache.zip && rm -v public_cache.zip) &
           (npx wrangler r2 object put gmodwiki/build_cache.zip --remote --file ./build_cache.zip && rm -v build_cache.zip) &
           (npx wrangler r2 object put gmodwiki/search_index.json --remote --file ./search_index.json && mv ./search_index.json ./public/) &
+          ([ -f ./embeddings.bin ] && npx wrangler r2 object put gmodwiki/embeddings.bin --remote --file ./embeddings.bin && mv ./embeddings.bin ./public/) &
+          ([ -f ./embeddings_manifest.json ] && npx wrangler r2 object put gmodwiki/embeddings_manifest.json --remote --file ./embeddings_manifest.json && mv ./embeddings_manifest.json ./public/) &
           wait
+
+      - name: Sync embeddings into Vectorize
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_AI_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: |
+          if [ -f ./public/embeddings.bin ]; then
+            npm run vectorize_sync
+          else
+            echo "no embeddings artifact present; skipping Vectorize sync"
+          fi
 
       # CF Publish
       - name: Publish Site

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ deleted_files.txt
 # These are generated files, shouldn't be tracked - they get rebuilt on build
 src/layouts/Layout.astro
 src/components/Sidebar.astro
+
+# documentation (kept local, not tracked)
+docs/
+
+# superpowers process scaffolding (plans, reviews, progress ledger)
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ deleted_files.txt
 src/layouts/Layout.astro
 src/components/Sidebar.astro
 
-# documentation (kept local, not tracked)
 docs/
-
-# superpowers process scaffolding (plans, reviews, progress ledger)
+.claude/
 .superpowers/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ RUN rm -rf \
     /app/node_modules/terser \
     /app/node_modules/@rollup \
     /app/node_modules/esbuild \
-    /app/node_modules/sharp \
-    /app/node_modules/@img \
-    /app/node_modules/astro
+    /app/node_modules/astro \
+    /app/node_modules/onnxruntime-node/bin/napi-v3/darwin \
+    /app/node_modules/onnxruntime-node/bin/napi-v3/win32 \
+    /app/node_modules/onnxruntime-web
 
 
 FROM base AS build-deps
@@ -32,9 +33,23 @@ RUN npm ci
 
 
 FROM build-deps AS builder
+# Bake the q8 model BEFORE copying source so Docker can cache this expensive
+# download step across source-only rebuilds.
+RUN printf '%s\n' \
+    'import { pipeline, env } from "@huggingface/transformers";' \
+    'env.cacheDir = "/app/hf-cache";' \
+    'env.allowRemoteModels = true;' \
+    'await pipeline("feature-extraction", "Xenova/bge-base-en-v1.5", { dtype: "q8" });' \
+    'console.log("Model baked at /app/hf-cache");' \
+    > /app/bake-model.mjs && node /app/bake-model.mjs
+
 COPY astro.config.mjs tsconfig.json ./
 COPY .astro ./
 COPY src ./src
+# Only core + adapters are needed for the site/offline build; the mcp/ servers
+# are deployed/published separately and aren't part of the Docker image.
+COPY semantic/core ./semantic/core
+COPY semantic/adapters ./semantic/adapters
 COPY build ./build
 COPY public ./public
 ENV BUILD_ENV=docker
@@ -47,6 +62,13 @@ FROM gcr.io/distroless/nodejs24-debian12 AS final
 WORKDIR /app
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
+# Baked model cache (populated during builder stage; no network needed at runtime)
+COPY --from=builder /app/hf-cache /app/hf-cache
+# Point runtime at the baked model cache and at the embeddings artifact inside dist/client/
+# (Astro copies all public/ files into dist/client/ during astrobuild).
+ENV MODEL_CACHE_DIR=/app/hf-cache
+ENV EMBEDDINGS_BIN=/app/dist/client/embeddings.bin
+ENV EMBEDDINGS_MANIFEST=/app/dist/client/embeddings_manifest.json
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=4321

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,6 @@ RUN printf '%s\n' \
 COPY astro.config.mjs tsconfig.json ./
 COPY .astro ./
 COPY src ./src
-# Only core + adapters are needed for the site/offline build; the mcp/ servers
-# are deployed/published separately and aren't part of the Docker image.
 COPY semantic/core ./semantic/core
 COPY semantic/adapters ./semantic/adapters
 COPY build ./build
@@ -62,10 +60,7 @@ FROM gcr.io/distroless/nodejs24-debian12 AS final
 WORKDIR /app
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
-# Baked model cache (populated during builder stage; no network needed at runtime)
 COPY --from=builder /app/hf-cache /app/hf-cache
-# Point runtime at the baked model cache and at the embeddings artifact inside dist/client/
-# (Astro copies all public/ files into dist/client/ during astrobuild).
 ENV MODEL_CACHE_DIR=/app/hf-cache
 ENV EMBEDDINGS_BIN=/app/dist/client/embeddings.bin
 ENV EMBEDDINGS_MANIFEST=/app/dist/client/embeddings_manifest.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN npm ci
 
 
 FROM build-deps AS builder
-# Bake the q8 model BEFORE copying source so Docker can cache this expensive
-# download step across source-only rebuilds.
+
+# Bake the q8 model
 RUN printf '%s\n' \
     'import { pipeline, env } from "@huggingface/transformers";' \
     'env.cacheDir = "/app/hf-cache";' \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You may use the [public site](https://gmodwiki.com), or even [host your own](htt
 - :mag_right: **Fast searching**
     - Both basic and full-site searching are implemented
     - Search results are not paginated
+- :robot: **Semantic search & MCP**
+    - Hybrid keyword + semantic search, with an MCP server for AI tools
 - :framed_picture: **Optimized images**
     - Image size reduced by > 40% with only a small loss in quality
 - :cloud: **Hosted entirely on The Cloud**
@@ -164,6 +166,51 @@ _⚠️ Be sure to replace `gmodwiki.com` with your domain!_
 ![image](https://github.com/CFC-Servers/gmodwiki/assets/7936439/0dd7cbac-d3e8-486c-9549-344b8f453f27)
 ![image](https://github.com/CFC-Servers/gmodwiki/assets/7936439/34b267ae-5036-45e1-91a1-b948702a89e2)
 ![image](https://github.com/CFC-Servers/gmodwiki/assets/7936439/e8133bac-c12a-4bbe-a7bf-fff30d1e2850)
+</details>
+
+## Use it in your AI assistant (MCP)
+
+The wiki is available as a hosted [MCP](https://modelcontextprotocol.io) server at `https://mcp.gmodwiki.com/mcp`, exposing `search_wiki` and `get_page` tools so assistants can look up GMod functions, hooks, and examples.
+
+**Claude Code** — install the plugin:
+```sh
+/plugin marketplace add CFC-Servers/gmodwiki
+/plugin install gmodwiki
+```
+
+<details>
+    <summary>:point_up_2: Other clients (Cursor, VS Code, Claude Desktop, …)</summary>
+
+<br>
+
+**Cursor** — `~/.cursor/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "gmodwiki": { "url": "https://mcp.gmodwiki.com/mcp", "transport": "streamable-http" }
+  }
+}
+```
+
+**VS Code (Copilot)** — `.vscode/mcp.json` (note: root key is `servers`):
+```json
+{
+  "servers": {
+    "gmodwiki": { "type": "http", "url": "https://mcp.gmodwiki.com/mcp" }
+  }
+}
+```
+
+**Claude Desktop / claude.ai** — Settings → Connectors → *Add custom connector* → `https://mcp.gmodwiki.com/mcp`
+
+**Any stdio-only client** — bridge with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
+```json
+{
+  "mcpServers": {
+    "gmodwiki": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.gmodwiki.com/mcp"] }
+  }
+}
+```
 </details>
 
 ## Dev

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ _⚠️ Be sure to replace `gmodwiki.com` with your domain!_
 
 The wiki is available as a hosted [MCP](https://modelcontextprotocol.io) server at `https://mcp.gmodwiki.com/mcp`, exposing `search_wiki` and `get_page` tools so assistants can look up GMod functions, hooks, and examples.
 
-**Claude Code** — install the plugin:
+**Claude Code**: install the plugin:
 ```sh
 /plugin marketplace add CFC-Servers/gmodwiki
 /plugin install gmodwiki
@@ -183,7 +183,7 @@ The wiki is available as a hosted [MCP](https://modelcontextprotocol.io) server 
 
 <br>
 
-**Cursor** — `~/.cursor/mcp.json`:
+**Cursor**: `~/.cursor/mcp.json`:
 ```json
 {
   "mcpServers": {
@@ -192,7 +192,7 @@ The wiki is available as a hosted [MCP](https://modelcontextprotocol.io) server 
 }
 ```
 
-**VS Code (Copilot)** — `.vscode/mcp.json` (note: root key is `servers`):
+**VS Code (Copilot)**: `.vscode/mcp.json` (note: root key is `servers`):
 ```json
 {
   "servers": {
@@ -201,9 +201,9 @@ The wiki is available as a hosted [MCP](https://modelcontextprotocol.io) server 
 }
 ```
 
-**Claude Desktop / claude.ai** — Settings → Connectors → *Add custom connector* → `https://mcp.gmodwiki.com/mcp`
+**Claude Desktop / claude.ai**: Settings → Connectors → *Add custom connector* → `https://mcp.gmodwiki.com/mcp`
 
-**Any stdio-only client** — bridge with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
+**Any stdio-only client**: bridge with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
 ```json
 {
   "mcpServers": {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,10 +75,7 @@ const DEFAULT_OPTIONS = {
   cacheLocation: undefined,
 };
 
-// Keep transformers.js/onnxruntime-node out of the CF Worker bundle.
-// Dynamic imports are still followed by Rollup; externalizing prevents them
-// from being inlined. Code is only reached on the Node path (hosted branch
-// returns early on CF), so the external reference is never executed there.
+// Keep transformers.js/onnxruntime-node out of the CF Worker bundle
 const viteSSRExternal = buildEnv === "production"
   ? ["@huggingface/transformers", "onnxruntime-node"]
   : [];

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,6 +75,14 @@ const DEFAULT_OPTIONS = {
   cacheLocation: undefined,
 };
 
+// Keep transformers.js/onnxruntime-node out of the CF Worker bundle.
+// Dynamic imports are still followed by Rollup; externalizing prevents them
+// from being inlined. Code is only reached on the Node path (hosted branch
+// returns early on CF), so the external reference is never executed there.
+const viteSSRExternal = buildEnv === "production"
+  ? ["@huggingface/transformers", "onnxruntime-node"]
+  : [];
+
 export default defineConfig({
   build: buildConfig,
   output: "server",
@@ -84,7 +92,10 @@ export default defineConfig({
   vite : {
     plugins: [
       ViteImageOptimizer(DEFAULT_OPTIONS)
-    ]
+    ],
+    ssr: {
+      external: viteSSRExternal,
+    },
   },
 
   integrations: [playformCompress({

--- a/build/build_embeddings_local.ts
+++ b/build/build_embeddings_local.ts
@@ -1,12 +1,4 @@
-// Generate embeddings.bin + embeddings_manifest.json locally from the existing
-// build/cache/gmod/*.json — WITHOUT running the full site build. Reads only the
-// local cache; the only network calls are Workers AI embed requests.
-//
-// Usage:
-//   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_AI_API_TOKEN=... \
-//     node --no-warnings=ExperimentalWarning --loader ts-node/esm ./scripts/build_embeddings_local.ts
-//
-// The token needs Workers AI (read) scope. Output lands in public/.
+// Generate embeddings.bin + embeddings_manifest.json locally from the existing build/cache/gmod/*.json
 import { buildEmbeddings } from "./modules/embeddings.js";
 import { WorkersAiEmbedder } from "./modules/workers_ai_embedder.js";
 

--- a/build/build_embeddings_local.ts
+++ b/build/build_embeddings_local.ts
@@ -1,0 +1,22 @@
+// Generate embeddings.bin + embeddings_manifest.json locally from the existing
+// build/cache/gmod/*.json — WITHOUT running the full site build. Reads only the
+// local cache; the only network calls are Workers AI embed requests.
+//
+// Usage:
+//   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_AI_API_TOKEN=... \
+//     node --no-warnings=ExperimentalWarning --loader ts-node/esm ./scripts/build_embeddings_local.ts
+//
+// The token needs Workers AI (read) scope. Output lands in public/.
+import { buildEmbeddings } from "./modules/embeddings.js";
+import { WorkersAiEmbedder } from "./modules/workers_ai_embedder.js";
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+const apiToken = process.env.CLOUDFLARE_AI_API_TOKEN;
+if (!accountId || !apiToken) {
+  console.error("Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_AI_API_TOKEN first.");
+  process.exit(1);
+}
+
+const embedder = new WorkersAiEmbedder(accountId, apiToken);
+const result = await buildEmbeddings({ cacheDir: "build/cache", outDir: "public", embedder });
+console.log(`embeddings: wrote ${result.total} vectors (${result.embedded} new/changed, ${result.deleted.length} removed)`);

--- a/build/fragments/script.js
+++ b/build/fragments/script.js
@@ -363,12 +363,25 @@ function UpdateSearch(limitResults = true) {
     };
     SearchResults.append(moreresults);
   }
-  if (SearchResults.children.length == 0) {
-    var noresults = document.createElement("span");
-    noresults.classList.add("noresults");
-    noresults.innerHTML = "No results.<br/>Press Enter to search the wiki.";
-    SearchResults.appendChild(noresults);
-  }
+  AddFullSearchCTA(SearchInput.value);
+}
+function AddFullSearchCTA(query) {
+  if (!query || query.trim().length < 2) return;
+  var hadResults = SearchResults.querySelectorAll("a, .sectionheader").length > 0;
+
+  var cta = document.createElement("a");
+  cta.href = "/websearch?query=" + encodeURIComponent(query);
+  cta.classList.add("full-search-cta");
+  if (!hadResults) cta.classList.add("full-search-cta-empty");
+  cta.innerHTML =
+    '<span class="mdi mdi-magnify"></span> Search all pages for ' +
+    '<strong>"' + query.replace(/</g, "&lt;") + '"</strong>' +
+    '<span class="full-search-hint">&#8629; Enter</span>';
+  cta.onclick = function () {
+    window.location.href = "/websearch?query=" + encodeURIComponent(query);
+    return false;
+  };
+  SearchResults.appendChild(cta);
 }
 var SectionHeader;
 var TitleCount = 0;

--- a/build/index.ts
+++ b/build/index.ts
@@ -5,6 +5,8 @@ import SearchManager from "./modules/search.js"
 import { setup } from "./setup.js"
 import { buildAllPages } from "./modules/pages.js"
 import { buildSearchIndex } from "./modules/build_search_index.js"
+import { buildEmbeddings } from "./modules/embeddings.js"
+import { WorkersAiEmbedder } from "./modules/workers_ai_embedder.js"
 
 const baseURL = "https://wiki.facepunch.com"
 const api = new ApiInterface(baseURL)
@@ -15,6 +17,16 @@ async function init() {
     await setup(api, staticContent)
     await buildAllPages(api, staticContent, searchManager)
     await buildSearchIndex(searchManager)
+
+    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+    const apiToken = process.env.CLOUDFLARE_AI_API_TOKEN
+    if (accountId && apiToken) {
+        const embedder = new WorkersAiEmbedder(accountId, apiToken)
+        const result = await buildEmbeddings({ cacheDir: "build/cache", outDir: "public", embedder })
+        console.log(`embeddings: wrote ${result.total} vectors (${result.embedded} new/changed, ${result.deleted.length} removed)`)
+    } else {
+        console.log("CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_AI_API_TOKEN not set; skipping embeddings generation")
+    }
 }
 
 init()

--- a/build/modules/categories/gmod_wiki_scraper/index.ts
+++ b/build/modules/categories/gmod_wiki_scraper/index.ts
@@ -1,10 +1,12 @@
 import * as cheerio from 'cheerio';
+import type { Element } from 'domhandler';
 
 type Realm = 'client' | 'menu' | 'server';
 
 interface WikiPage {
   title: string;
   content: string;
+  markup: string;
 }
 
 interface Class {
@@ -136,8 +138,8 @@ export class WikiScraper {
 
   public parseFunctionPage(pageContent: string): Function {
     const $ = this.parseContent(pageContent);
-    const name = $('function').attr().name;
-    const parent = $('function').attr().parent;
+    const name = $('function').attr('name') ?? '';
+    const parent = $('function').attr('parent') ?? '';
     const description = $('function > description').html();
     const $sourceFile = $('function > file');
     const realmsRaw = this.trimMultiLineString($('function > realm').text());
@@ -146,7 +148,7 @@ export class WikiScraper {
     const overloads: Array<FunctionOverload> = [];
     const returnValues: Array<FunctionReturnValue> = [];
 
-    const parseArg = (arg: cheerio.Element, i: number) => {
+    const parseArg = (arg: Element, i: number) => {
         const description = $(arg).html();
 
         const argument: FunctionArgument = {
@@ -167,7 +169,7 @@ export class WikiScraper {
 
     const $argsBlocks = $("function > args");
 
-    $($argsBlocks[0]).children().each((i: number, arg: cheerio.Element) => {
+    $($argsBlocks[0]).children().each((i: number, arg: Element) => {
         args.push(parseArg(arg, i))
     })
 
@@ -177,7 +179,7 @@ export class WikiScraper {
             arguments: []
         }
 
-        $($argsBlocks[i]).children().each((i: number, arg: cheerio.Element) => {
+        $($argsBlocks[i]).children().each((i: number, arg: Element) => {
             overload.arguments.push(parseArg(arg, i))
         })
 
@@ -230,7 +232,7 @@ export class WikiScraper {
     if ($sourceFile.length > 0) {
       const file = $sourceFile.text();
 
-      const line = $sourceFile.attr().line.replace('L', '');
+      const line = ($sourceFile.attr('line') ?? '').replace('L', '');
       const lines = line.split('-');
       const lineStart = lines[0];
       const lineEnd = lines[1];
@@ -268,7 +270,7 @@ export class WikiScraper {
 
   public parseTypePage(pageContent: string): Type {
     const $ = this.parseContent(pageContent);
-    const name = $('type').attr().name;
+    const name = $('type').attr('name') ?? '';
     const description = $('type > summary').html();
 
     const type: Type = {
@@ -417,7 +419,9 @@ export class WikiScraper {
   }
 
   private parseContent(content: string): cheerio.CheerioAPI {
-    return cheerio.load(content, { decodeEntities: false });
+    // `decodeEntities` is not in cheerio 1.x's option types (and is ignored at
+    // runtime); cast to keep the call unchanged without a type error.
+    return cheerio.load(content, { decodeEntities: false } as cheerio.CheerioOptions);
   }
 
   private trimMultiLineString(str: string): string {

--- a/build/modules/categories/gmod_wiki_scraper/index.ts
+++ b/build/modules/categories/gmod_wiki_scraper/index.ts
@@ -419,8 +419,6 @@ export class WikiScraper {
   }
 
   private parseContent(content: string): cheerio.CheerioAPI {
-    // `decodeEntities` is not in cheerio 1.x's option types (and is ignored at
-    // runtime); cast to keep the call unchanged without a type error.
     return cheerio.load(content, { decodeEntities: false } as cheerio.CheerioOptions);
   }
 

--- a/build/modules/clear_recent_changes.ts
+++ b/build/modules/clear_recent_changes.ts
@@ -1,4 +1,5 @@
 import * as cheerio from "cheerio"
+import type { Element } from "domhandler"
 import { promises as fs } from "fs"
 import ApiInterface from "./api_interface.js"
 
@@ -22,7 +23,7 @@ const getLastBuildTime = async () => {
   return parseInt(lastBuildTime, 10)
 }
 
-const getURLFromRow = ($: cheerio.CheerioAPI, row: cheerio.Element) => {
+const getURLFromRow = ($: cheerio.CheerioAPI, row: Element) => {
   return $(row).find("div.address a").attr("href")
 }
 

--- a/build/modules/css.ts
+++ b/build/modules/css.ts
@@ -31,6 +31,7 @@ const mdiWhitelist = [
   ".mdi-language-lua",
   ".mdi-library-shelves",
   ".mdi-link-variant",
+  ".mdi-magnify",
   ".mdi-menu",
   ".mdi-pencil",
   ".mdi-robot",
@@ -220,6 +221,12 @@ export async function processCss(contentHandler: StaticContentHandler) {
 
   // Add scrollbar for the body tabs
   newContent = `${newContent} .body-tabs { overflow-x: auto; }\n`;
+
+  // Full-search CTA pinned at bottom of sidebar search results
+  newContent = `${newContent} .full-search-cta { display: block; padding: 8px 10px; margin-top: 6px; border-top: 1px solid rgba(128, 128, 128, 0.3); font-size: 0.9em; cursor: pointer; }\n`;
+  newContent = `${newContent} .full-search-cta:hover { background: rgba(128, 128, 128, 0.12); }\n`;
+  newContent = `${newContent} .full-search-cta-empty { border-top: none; }\n`;
+  newContent = `${newContent} .full-search-hint { float: right; opacity: 0.6; font-size: 0.85em; }\n`;
 
   newContent = removeDeadStyles(newContent);
   newContent = optimizeCss(newContent);

--- a/build/modules/download_caches.sh
+++ b/build/modules/download_caches.sh
@@ -17,9 +17,6 @@ download_cache() {
     rm -f "${name}"
 }
 
-# Embeddings artifact: not bundled in the cache zips (kept out of the Cloudflare
-# deploy, like search_index.json). Pull it standalone into public/ so incremental
-# builds can reuse the prior vectors. Keep the files (do not delete).
 download_embedding() {
     local name="$1"
     mkdir -p public

--- a/build/modules/download_caches.sh
+++ b/build/modules/download_caches.sh
@@ -17,6 +17,21 @@ download_cache() {
     rm -f "${name}"
 }
 
+# Embeddings artifact: not bundled in the cache zips (kept out of the Cloudflare
+# deploy, like search_index.json). Pull it standalone into public/ so incremental
+# builds can reuse the prior vectors. Keep the files (do not delete).
+download_embedding() {
+    local name="$1"
+    mkdir -p public
+
+    if ! curl --location --fail --show-error --silent --output "public/${name}" "https://storage.gmodwiki.com/${name}"; then
+        echo "WARNING: failed to download ${name}, continuing without it (a fresh full embed will run)"
+        rm -f "public/${name}"
+    fi
+}
+
 download_cache build_cache.zip &
 download_cache public_cache.zip &
+download_embedding embeddings.bin &
+download_embedding embeddings_manifest.json &
 wait

--- a/build/modules/embeddings.test.ts
+++ b/build/modules/embeddings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { promises as fs } from "fs";
 import os from "os";
 import path from "path";
+
 import { buildEmbeddings, loadRawEntries, mergeManifest } from "./embeddings.js";
 import { decodeEmbeddings } from "../../semantic/core/binary.js";
 import { EMBEDDING_DIMS } from "../../semantic/core/model.js";
@@ -19,6 +20,7 @@ const fakeEmbedder = {
 async function seedCache(dir: string, pages: { address: string; rev: number }[]) {
   const gmod = path.join(dir, "gmod");
   await fs.mkdir(gmod, { recursive: true });
+
   for (const p of pages) {
     await fs.writeFile(
       path.join(gmod, `${p.address}.json`),
@@ -28,6 +30,7 @@ async function seedCache(dir: string, pages: { address: string; rev: number }[])
 }
 
 let tmp: string;
+
 beforeEach(async () => {
   tmp = await fs.mkdtemp(path.join(os.tmpdir(), "emb-"));
 });
@@ -48,6 +51,7 @@ describe("buildEmbeddings", () => {
 
     // Change B, add C, remove nothing
     await seedCache(cacheDir, [{ address: "A", rev: 1 }, { address: "B", rev: 2 }, { address: "C", rev: 1 }]);
+
     const inc = await buildEmbeddings({ cacheDir, outDir, embedder: fakeEmbedder });
     expect(inc.embedded).toBe(2);
     expect(inc.total).toBe(3);
@@ -58,6 +62,7 @@ describe("loadRawEntries", () => {
   it("reads json entries from <cacheDir>/gmod", async () => {
     const cacheDir = path.join(tmp, "cache");
     await seedCache(cacheDir, [{ address: "A", rev: 1 }]);
+
     const entries = await loadRawEntries(cacheDir);
     expect(entries).toHaveLength(1);
     expect(entries[0].address).toBe("A");

--- a/build/modules/embeddings.test.ts
+++ b/build/modules/embeddings.test.ts
@@ -10,7 +10,7 @@ const fakeEmbedder = {
   async embedBatch(texts: string[]) {
     return texts.map((t) => {
       const v = new Float32Array(EMBEDDING_DIMS);
-      v[0] = t.length; // deterministic, content-dependent
+      v[0] = t.length;
       return v;
     });
   },
@@ -49,7 +49,7 @@ describe("buildEmbeddings", () => {
     // Change B, add C, remove nothing
     await seedCache(cacheDir, [{ address: "A", rev: 1 }, { address: "B", rev: 2 }, { address: "C", rev: 1 }]);
     const inc = await buildEmbeddings({ cacheDir, outDir, embedder: fakeEmbedder });
-    expect(inc.embedded).toBe(2); // B + C only
+    expect(inc.embedded).toBe(2);
     expect(inc.total).toBe(3);
   });
 });

--- a/build/modules/embeddings.test.ts
+++ b/build/modules/embeddings.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { buildEmbeddings, loadRawEntries, mergeManifest } from "./embeddings.js";
+import { decodeEmbeddings } from "../../semantic/core/binary.js";
+import { EMBEDDING_DIMS } from "../../semantic/core/model.js";
+
+const fakeEmbedder = {
+  async embedBatch(texts: string[]) {
+    return texts.map((t) => {
+      const v = new Float32Array(EMBEDDING_DIMS);
+      v[0] = t.length; // deterministic, content-dependent
+      return v;
+    });
+  },
+};
+
+async function seedCache(dir: string, pages: { address: string; rev: number }[]) {
+  const gmod = path.join(dir, "gmod");
+  await fs.mkdir(gmod, { recursive: true });
+  for (const p of pages) {
+    await fs.writeFile(
+      path.join(gmod, `${p.address}.json`),
+      JSON.stringify({ address: p.address, title: p.address, tags: "function", html: `<p>${p.address}</p>`, revisionId: p.rev }),
+    );
+  }
+}
+
+let tmp: string;
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), "emb-"));
+});
+
+describe("buildEmbeddings", () => {
+  it("does a full build then an incremental build", async () => {
+    const cacheDir = path.join(tmp, "cache");
+    const outDir = path.join(tmp, "out");
+    await fs.mkdir(outDir, { recursive: true });
+    await seedCache(cacheDir, [{ address: "A", rev: 1 }, { address: "B", rev: 1 }]);
+
+    const full = await buildEmbeddings({ cacheDir, outDir, embedder: fakeEmbedder });
+    expect(full.embedded).toBe(2);
+    expect(full.total).toBe(2);
+
+    const bin = await fs.readFile(path.join(outDir, "embeddings.bin"));
+    expect(decodeEmbeddings(new Uint8Array(bin)).count).toBe(2);
+
+    // Change B, add C, remove nothing
+    await seedCache(cacheDir, [{ address: "A", rev: 1 }, { address: "B", rev: 2 }, { address: "C", rev: 1 }]);
+    const inc = await buildEmbeddings({ cacheDir, outDir, embedder: fakeEmbedder });
+    expect(inc.embedded).toBe(2); // B + C only
+    expect(inc.total).toBe(3);
+  });
+});
+
+describe("loadRawEntries", () => {
+  it("reads json entries from <cacheDir>/gmod", async () => {
+    const cacheDir = path.join(tmp, "cache");
+    await seedCache(cacheDir, [{ address: "A", rev: 1 }]);
+    const entries = await loadRawEntries(cacheDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].address).toBe("A");
+  });
+});

--- a/build/modules/embeddings.ts
+++ b/build/modules/embeddings.ts
@@ -1,0 +1,108 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { diffManifest, changeKeyFor } from "./embeddings_diff.js";
+import { encodeEmbeddings, decodeEmbeddings } from "../../semantic/core/binary.js";
+import { buildEmbedText, buildSnippet } from "../../semantic/core/embed-text.js";
+import { EMBEDDING_DIMS, MODEL_ID } from "../../semantic/core/model.js";
+import type { Manifest, ManifestEntry, RawEntry } from "../../semantic/core/types.js";
+
+export async function loadRawEntries(cacheDir: string): Promise<RawEntry[]> {
+  const gmod = path.join(cacheDir, "gmod");
+  const files = await fs.readdir(gmod);
+  const entries: RawEntry[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const raw = await fs.readFile(path.join(gmod, file), "utf8");
+    let obj: any;
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      console.warn(`skipping unparseable ${file}`);
+      continue;
+    }
+    if (!obj.address || !obj.html) continue;
+    entries.push({
+      address: obj.address,
+      title: obj.title ?? obj.address,
+      tags: obj.tags ?? "",
+      markup: obj.markup,
+      html: obj.html,
+      revisionId: obj.revisionId,
+    });
+  }
+  return entries;
+}
+
+async function loadPrev(outDir: string): Promise<{ manifest: Manifest; vecById: Map<string, Float32Array> } | null> {
+  try {
+    const manifest: Manifest = JSON.parse(await fs.readFile(path.join(outDir, "embeddings_manifest.json"), "utf8"));
+    const bin = await fs.readFile(path.join(outDir, "embeddings.bin"));
+    const { vectors } = decodeEmbeddings(new Uint8Array(bin));
+    const vecById = new Map<string, Float32Array>();
+    manifest.entries.forEach((e, i) => vecById.set(e.id, vectors[i]));
+    return { manifest, vecById };
+  } catch {
+    return null;
+  }
+}
+
+export function mergeManifest(
+  prev: Manifest | null,
+  entries: RawEntry[],
+  newVecById: Map<string, Float32Array>,
+  prevVecById: Map<string, Float32Array>,
+): { manifest: Manifest; vectors: Float32Array[] } {
+  const manifestEntries: ManifestEntry[] = [];
+  const vectors: Float32Array[] = [];
+
+  for (const entry of entries) {
+    const vector = newVecById.get(entry.address) ?? prevVecById.get(entry.address);
+    if (!vector) continue; // should not happen; unchanged entries keep prior vector
+    manifestEntries.push({
+      id: entry.address,
+      address: entry.address,
+      title: entry.title,
+      snippet: buildSnippet(entry),
+      url: "/" + entry.address,
+      changeKey: changeKeyFor(entry),
+    });
+    vectors.push(vector);
+  }
+
+  return {
+    manifest: { model: MODEL_ID, dims: EMBEDDING_DIMS, count: manifestEntries.length, entries: manifestEntries },
+    vectors,
+  };
+}
+
+export async function buildEmbeddings(opts: {
+  cacheDir: string;
+  outDir: string;
+  embedder: { embedBatch(texts: string[]): Promise<Float32Array[]> };
+}): Promise<{ embedded: number; deleted: string[]; total: number }> {
+  const entries = await loadRawEntries(opts.cacheDir);
+  const prev = await loadPrev(opts.outDir);
+  const diff = diffManifest(prev?.manifest ?? null, entries);
+
+  console.log(`embeddings: ${diff.toEmbed.length} to embed, ${diff.unchanged.length} unchanged, ${diff.toDelete.length} removed`);
+
+  const newVecById = new Map<string, Float32Array>();
+  if (diff.toEmbed.length > 0) {
+    const texts = diff.toEmbed.map(buildEmbedText);
+    const vectors = await opts.embedder.embedBatch(texts);
+    diff.toEmbed.forEach((e, i) => newVecById.set(e.address, vectors[i]));
+  }
+
+  const { manifest, vectors } = mergeManifest(
+    prev?.manifest ?? null,
+    entries,
+    newVecById,
+    prev?.vecById ?? new Map(),
+  );
+
+  await fs.mkdir(opts.outDir, { recursive: true });
+  await fs.writeFile(path.join(opts.outDir, "embeddings.bin"), encodeEmbeddings(vectors, EMBEDDING_DIMS));
+  await fs.writeFile(path.join(opts.outDir, "embeddings_manifest.json"), JSON.stringify(manifest));
+
+  return { embedded: diff.toEmbed.length, deleted: diff.toDelete, total: manifest.count };
+}

--- a/build/modules/embeddings.ts
+++ b/build/modules/embeddings.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import { diffManifest, changeKeyFor } from "./embeddings_diff.js";
 import { encodeEmbeddings, decodeEmbeddings } from "../../semantic/core/binary.js";
-import { buildEmbedText, buildSnippet } from "../../semantic/core/embed-text.js";
+import { buildEmbedText, buildSnippet, kindFor } from "../../semantic/core/embed-text.js";
 import { EMBEDDING_DIMS, MODEL_ID } from "../../semantic/core/model.js";
 import type { Manifest, ManifestEntry, RawEntry } from "../../semantic/core/types.js";
 
@@ -64,6 +64,7 @@ export function mergeManifest(
       title: entry.title,
       snippet: buildSnippet(entry),
       url: "/" + entry.address,
+      kind: kindFor(entry),
       changeKey: changeKeyFor(entry),
     });
     vectors.push(vector);

--- a/build/modules/embeddings.ts
+++ b/build/modules/embeddings.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import path from "path";
+
 import { diffManifest, changeKeyFor } from "./embeddings_diff.js";
 import { encodeEmbeddings, decodeEmbeddings } from "../../semantic/core/binary.js";
 import { buildEmbedText, buildSnippet, kindFor } from "../../semantic/core/embed-text.js";
@@ -10,8 +11,10 @@ export async function loadRawEntries(cacheDir: string): Promise<RawEntry[]> {
   const gmod = path.join(cacheDir, "gmod");
   const files = await fs.readdir(gmod);
   const entries: RawEntry[] = [];
+
   for (const file of files) {
     if (!file.endsWith(".json")) continue;
+
     const raw = await fs.readFile(path.join(gmod, file), "utf8");
     let obj: any;
     try {
@@ -20,7 +23,9 @@ export async function loadRawEntries(cacheDir: string): Promise<RawEntry[]> {
       console.warn(`skipping unparseable ${file}`);
       continue;
     }
+
     if (!obj.address || !obj.html) continue;
+
     entries.push({
       address: obj.address,
       title: obj.title ?? obj.address,
@@ -30,6 +35,7 @@ export async function loadRawEntries(cacheDir: string): Promise<RawEntry[]> {
       revisionId: obj.revisionId,
     });
   }
+
   return entries;
 }
 
@@ -37,9 +43,12 @@ async function loadPrev(outDir: string): Promise<{ manifest: Manifest; vecById: 
   try {
     const manifest: Manifest = JSON.parse(await fs.readFile(path.join(outDir, "embeddings_manifest.json"), "utf8"));
     const bin = await fs.readFile(path.join(outDir, "embeddings.bin"));
+
+    // Manifest entries and binary vectors are parallel arrays, same order.
     const { vectors } = decodeEmbeddings(new Uint8Array(bin));
     const vecById = new Map<string, Float32Array>();
     manifest.entries.forEach((e, i) => vecById.set(e.id, vectors[i]));
+
     return { manifest, vecById };
   } catch {
     return null;
@@ -58,6 +67,7 @@ export function mergeManifest(
   for (const entry of entries) {
     const vector = newVecById.get(entry.address) ?? prevVecById.get(entry.address);
     if (!vector) continue; // should not happen; unchanged entries keep prior vector
+
     manifestEntries.push({
       id: entry.address,
       address: entry.address,
@@ -83,6 +93,9 @@ export async function buildEmbeddings(opts: {
 }): Promise<{ embedded: number; deleted: string[]; total: number }> {
   const entries = await loadRawEntries(opts.cacheDir);
   const prev = await loadPrev(opts.outDir);
+
+  // Incremental: only pages whose changeKey moved get re-embedded,
+  // everything else reuses its previous vector.
   const diff = diffManifest(prev?.manifest ?? null, entries);
 
   console.log(`embeddings: ${diff.toEmbed.length} to embed, ${diff.unchanged.length} unchanged, ${diff.toDelete.length} removed`);

--- a/build/modules/embeddings_diff.test.ts
+++ b/build/modules/embeddings_diff.test.ts
@@ -26,8 +26,8 @@ describe("diffManifest", () => {
     const prev: Manifest = {
       model: "m", dims: 768, count: 2,
       entries: [
-        { id: "A", address: "A", title: "A", snippet: "", url: "/A", changeKey: "1" },
-        { id: "B", address: "B", title: "B", snippet: "", url: "/B", changeKey: "1" },
+        { id: "A", address: "A", title: "A", snippet: "", url: "/A", kind: "other", changeKey: "1" },
+        { id: "B", address: "B", title: "B", snippet: "", url: "/B", kind: "other", changeKey: "1" },
       ],
     };
     const d = diffManifest(prev, [mk("A", 1), mk("B", 2), mk("C", 1)]);
@@ -38,7 +38,7 @@ describe("diffManifest", () => {
   it("marks removed pages for deletion", () => {
     const prev: Manifest = {
       model: "m", dims: 768, count: 1,
-      entries: [{ id: "Z", address: "Z", title: "Z", snippet: "", url: "/Z", changeKey: "1" }],
+      entries: [{ id: "Z", address: "Z", title: "Z", snippet: "", url: "/Z", kind: "other", changeKey: "1" }],
     };
     const d = diffManifest(prev, [mk("A", 1)]);
     expect(d.toDelete).toEqual(["Z"]);

--- a/build/modules/embeddings_diff.test.ts
+++ b/build/modules/embeddings_diff.test.ts
@@ -10,6 +10,7 @@ describe("changeKeyFor", () => {
   it("uses revisionId when present", () => {
     expect(changeKeyFor(mk("A", 7))).toBe("7");
   });
+
   it("falls back to a content hash when revisionId is absent", () => {
     const e: RawEntry = { address: "A", title: "A", tags: "", html: "<p>hi</p>" };
     expect(changeKeyFor(e).startsWith("h:")).toBe(true);
@@ -19,9 +20,11 @@ describe("changeKeyFor", () => {
 describe("diffManifest", () => {
   it("embeds everything on a fresh build", () => {
     const d = diffManifest(null, [mk("A", 1), mk("B", 1)]);
+
     expect(d.toEmbed.map((e) => e.address).sort()).toEqual(["A", "B"]);
     expect(d.toDelete).toEqual([]);
   });
+
   it("embeds only changed/new and deletes removed", () => {
     const prev: Manifest = {
       model: "m", dims: 768, count: 2,
@@ -30,17 +33,22 @@ describe("diffManifest", () => {
         { id: "B", address: "B", title: "B", snippet: "", url: "/B", kind: "other", changeKey: "1" },
       ],
     };
+
     const d = diffManifest(prev, [mk("A", 1), mk("B", 2), mk("C", 1)]);
+
     expect(d.toEmbed.map((e) => e.address).sort()).toEqual(["B", "C"]);
     expect(d.toDelete).toEqual([]); // changed ids are upserted, not deleted
     expect(d.unchanged).toEqual(["A"]);
   });
+
   it("marks removed pages for deletion", () => {
     const prev: Manifest = {
       model: "m", dims: 768, count: 1,
       entries: [{ id: "Z", address: "Z", title: "Z", snippet: "", url: "/Z", kind: "other", changeKey: "1" }],
     };
+
     const d = diffManifest(prev, [mk("A", 1)]);
+
     expect(d.toDelete).toEqual(["Z"]);
     expect(d.toEmbed.map((e) => e.address)).toEqual(["A"]);
   });

--- a/build/modules/embeddings_diff.test.ts
+++ b/build/modules/embeddings_diff.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { changeKeyFor, diffManifest } from "./embeddings_diff.js";
+import type { Manifest, RawEntry } from "../../semantic/core/types.js";
+
+const mk = (address: string, rev: number): RawEntry => ({
+  address, title: address, tags: "function", html: `<p>${address}</p>`, revisionId: rev,
+});
+
+describe("changeKeyFor", () => {
+  it("uses revisionId when present", () => {
+    expect(changeKeyFor(mk("A", 7))).toBe("7");
+  });
+  it("falls back to a content hash when revisionId is absent", () => {
+    const e: RawEntry = { address: "A", title: "A", tags: "", html: "<p>hi</p>" };
+    expect(changeKeyFor(e).startsWith("h:")).toBe(true);
+  });
+});
+
+describe("diffManifest", () => {
+  it("embeds everything on a fresh build", () => {
+    const d = diffManifest(null, [mk("A", 1), mk("B", 1)]);
+    expect(d.toEmbed.map((e) => e.address).sort()).toEqual(["A", "B"]);
+    expect(d.toDelete).toEqual([]);
+  });
+  it("embeds only changed/new and deletes removed", () => {
+    const prev: Manifest = {
+      model: "m", dims: 768, count: 2,
+      entries: [
+        { id: "A", address: "A", title: "A", snippet: "", url: "/A", changeKey: "1" },
+        { id: "B", address: "B", title: "B", snippet: "", url: "/B", changeKey: "1" },
+      ],
+    };
+    const d = diffManifest(prev, [mk("A", 1), mk("B", 2), mk("C", 1)]);
+    expect(d.toEmbed.map((e) => e.address).sort()).toEqual(["B", "C"]);
+    expect(d.toDelete).toEqual([]); // changed ids are upserted, not deleted
+    expect(d.unchanged).toEqual(["A"]);
+  });
+  it("marks removed pages for deletion", () => {
+    const prev: Manifest = {
+      model: "m", dims: 768, count: 1,
+      entries: [{ id: "Z", address: "Z", title: "Z", snippet: "", url: "/Z", changeKey: "1" }],
+    };
+    const d = diffManifest(prev, [mk("A", 1)]);
+    expect(d.toDelete).toEqual(["Z"]);
+    expect(d.toEmbed.map((e) => e.address)).toEqual(["A"]);
+  });
+});

--- a/build/modules/embeddings_diff.ts
+++ b/build/modules/embeddings_diff.ts
@@ -1,19 +1,25 @@
 import type { Manifest, RawEntry } from "../../semantic/core/types.js";
 import { buildEmbedText } from "../../semantic/core/embed-text.js";
 
+// FNV-1a. Not cryptographic, just a cheap stable fingerprint for change detection.
 function stableHash(s: string): string {
   let h = 2166136261;
+
   for (let i = 0; i < s.length; i++) {
     h ^= s.charCodeAt(i);
     h = Math.imul(h, 16777619);
   }
+
   return "h:" + (h >>> 0).toString(16);
 }
 
+// The wiki's revisionId is the authoritative change signal; hash the embed
+// text only when the scrape didn't capture one.
 export function changeKeyFor(entry: RawEntry): string {
   if (entry.revisionId !== undefined && entry.revisionId !== null) {
     return String(entry.revisionId);
   }
+
   return stableHash(buildEmbedText(entry));
 }
 
@@ -24,11 +30,13 @@ export function diffManifest(
   if (!prev) {
     return { toEmbed: [...entries], toDelete: [], unchanged: [] };
   }
+
   const prevByAddress = new Map(prev.entries.map((e) => [e.address, e]));
   const newAddresses = new Set(entries.map((e) => e.address));
 
   const toEmbed: RawEntry[] = [];
   const unchanged: string[] = [];
+
   for (const entry of entries) {
     const prior = prevByAddress.get(entry.address);
     if (prior && prior.changeKey === changeKeyFor(entry)) {
@@ -37,6 +45,7 @@ export function diffManifest(
       toEmbed.push(entry);
     }
   }
+
   const toDelete = prev.entries
     .map((e) => e.address)
     .filter((address) => !newAddresses.has(address));

--- a/build/modules/embeddings_diff.ts
+++ b/build/modules/embeddings_diff.ts
@@ -1,0 +1,45 @@
+import type { Manifest, RawEntry } from "../../semantic/core/types.js";
+import { buildEmbedText } from "../../semantic/core/embed-text.js";
+
+function stableHash(s: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return "h:" + (h >>> 0).toString(16);
+}
+
+export function changeKeyFor(entry: RawEntry): string {
+  if (entry.revisionId !== undefined && entry.revisionId !== null) {
+    return String(entry.revisionId);
+  }
+  return stableHash(buildEmbedText(entry));
+}
+
+export function diffManifest(
+  prev: Manifest | null,
+  entries: RawEntry[],
+): { toEmbed: RawEntry[]; toDelete: string[]; unchanged: string[] } {
+  if (!prev) {
+    return { toEmbed: [...entries], toDelete: [], unchanged: [] };
+  }
+  const prevByAddress = new Map(prev.entries.map((e) => [e.address, e]));
+  const newAddresses = new Set(entries.map((e) => e.address));
+
+  const toEmbed: RawEntry[] = [];
+  const unchanged: string[] = [];
+  for (const entry of entries) {
+    const prior = prevByAddress.get(entry.address);
+    if (prior && prior.changeKey === changeKeyFor(entry)) {
+      unchanged.push(entry.address);
+    } else {
+      toEmbed.push(entry);
+    }
+  }
+  const toDelete = prev.entries
+    .map((e) => e.address)
+    .filter((address) => !newAddresses.has(address));
+
+  return { toEmbed, toDelete, unchanged };
+}

--- a/build/modules/get_page_manifest.ts
+++ b/build/modules/get_page_manifest.ts
@@ -1,5 +1,6 @@
 // Finds all individual pages for the website
 import * as cheerio from "cheerio"
+import type { Element } from "domhandler"
 import type ApiInterface from "./api_interface.js"
 
 interface PagelistResponse {
@@ -32,7 +33,7 @@ export async function getAllPagesForCategory(api: ApiInterface, category: WikiCa
     const $ = cheerio.load(html)
     const hrefs: string[] = []
 
-    $("a[href]").each((_: number, elem: cheerio.Element) => {
+    $("a[href]").each((_: number, elem: Element) => {
         const href = $(elem).attr("href")
         if (href) {
             hrefs.push(href)

--- a/build/modules/search.ts
+++ b/build/modules/search.ts
@@ -56,6 +56,7 @@ class SearchManager {
 
       const $ = cheerio.load(body)
       $("script, style").remove()
+      $(".function_links").remove() // drops the "Search Github" link from indexed text
       $("br").replaceWith("\n")
 
       function traverse(node: any) {

--- a/build/modules/upload_caches.sh
+++ b/build/modules/upload_caches.sh
@@ -11,13 +11,18 @@ wait
 (npx wrangler r2 object put gmodwiki/build_cache.zip --remote --file ./build_cache.zip && rm -v build_cache.zip) &
 wait
 
+# Embeddings artifact (semantic search dataset)
+(npx wrangler r2 object put gmodwiki/embeddings.bin --remote --file ./public/embeddings.bin) &
+(npx wrangler r2 object put gmodwiki/embeddings_manifest.json --remote --file ./public/embeddings_manifest.json) &
+wait
+
 # Purge-a da cache-a 🤌
 if [[ -n "$CLOUDFLARE_ZONE_ID" && -n "$CLOUDFLARE_CACHE_API_KEY" ]]; then
     echo "Purging Cloudflare edge cache for cache archives..."
     curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
         -H "Authorization: Bearer ${CLOUDFLARE_CACHE_API_KEY}" \
         -H "Content-Type: application/json" \
-        --data '{"files":["https://storage.gmodwiki.com/public_cache.zip","https://storage.gmodwiki.com/build_cache.zip"]}'
+        --data '{"files":["https://storage.gmodwiki.com/public_cache.zip","https://storage.gmodwiki.com/build_cache.zip","https://storage.gmodwiki.com/embeddings.bin","https://storage.gmodwiki.com/embeddings_manifest.json"]}'
     echo
 else
     echo "WARNING: CLOUDFLARE_ZONE_ID / CLOUDFLARE_CACHE_API_KEY not set; skipping edge cache purge."

--- a/build/modules/vectorize_sync.ts
+++ b/build/modules/vectorize_sync.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "fs";
+
 import { decodeEmbeddings } from "../../semantic/core/binary.js";
 import type { Manifest } from "../../semantic/core/types.js";
 
@@ -17,7 +18,7 @@ async function upsertAll() {
   const manifest: Manifest = JSON.parse(await fs.readFile("public/embeddings_manifest.json", "utf8"));
   const { vectors } = decodeEmbeddings(new Uint8Array(await fs.readFile("public/embeddings.bin")));
 
-  // NDJSON: one vector object per line.
+  // Vectorize's upsert endpoint takes NDJSON: one vector object per line.
   const lines = manifest.entries.map((e, i) =>
     JSON.stringify({
       id: e.id,
@@ -28,20 +29,24 @@ async function upsertAll() {
 
   // Batch to keep request bodies reasonable.
   const BATCH = 1000;
+
   for (let i = 0; i < lines.length; i += BATCH) {
     const body = lines.slice(i, i + BATCH).join("\n");
+
     const res = await fetch(`${base}/upsert`, {
       method: "POST",
       headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/x-ndjson" },
       body,
     });
     if (!res.ok) throw new Error(`upsert failed: ${res.status} ${await res.text()}`);
+
     console.log(`upserted ${Math.min(i + BATCH, lines.length)}/${lines.length}`);
   }
 }
 
 async function deleteRemoved() {
   let ids: string[] = [];
+
   try {
     const deleted: string[] = JSON.parse(await fs.readFile("deleted_files.json", "utf8"));
     ids = deleted
@@ -50,12 +55,15 @@ async function deleteRemoved() {
   } catch {
     return;
   }
+
   if (ids.length === 0) return;
+
   const res = await fetch(`${base}/delete_by_ids`, {
     method: "POST",
     headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/json" },
     body: JSON.stringify({ ids }),
   });
+
   if (!res.ok) console.warn(`delete_by_ids failed: ${res.status} ${await res.text()}`);
   else console.log(`requested deletion of ${ids.length} ids`);
 }

--- a/build/modules/vectorize_sync.ts
+++ b/build/modules/vectorize_sync.ts
@@ -1,0 +1,67 @@
+import { promises as fs } from "fs";
+import { decodeEmbeddings } from "../../semantic/core/binary.js";
+import type { Manifest } from "../../semantic/core/types.js";
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID!;
+const apiToken = process.env.CLOUDFLARE_AI_API_TOKEN!;
+const INDEX = "gmodwiki-embeddings";
+
+if (!accountId || !apiToken) {
+  console.error("CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_AI_API_TOKEN are required");
+  process.exit(1);
+}
+
+const base = `https://api.cloudflare.com/client/v4/accounts/${accountId}/vectorize/v2/indexes/${INDEX}`;
+
+async function upsertAll() {
+  const manifest: Manifest = JSON.parse(await fs.readFile("public/embeddings_manifest.json", "utf8"));
+  const { vectors } = decodeEmbeddings(new Uint8Array(await fs.readFile("public/embeddings.bin")));
+
+  // NDJSON: one vector object per line.
+  const lines = manifest.entries.map((e, i) =>
+    JSON.stringify({
+      id: e.id,
+      values: Array.from(vectors[i]),
+      metadata: { title: e.title, url: e.url, snippet: e.snippet },
+    }),
+  );
+
+  // Batch to keep request bodies reasonable.
+  const BATCH = 1000;
+  for (let i = 0; i < lines.length; i += BATCH) {
+    const body = lines.slice(i, i + BATCH).join("\n");
+    const res = await fetch(`${base}/upsert`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/x-ndjson" },
+      body,
+    });
+    if (!res.ok) throw new Error(`upsert failed: ${res.status} ${await res.text()}`);
+    console.log(`upserted ${Math.min(i + BATCH, lines.length)}/${lines.length}`);
+  }
+}
+
+async function deleteRemoved() {
+  let ids: string[] = [];
+  try {
+    const deleted: string[] = JSON.parse(await fs.readFile("deleted_files.json", "utf8"));
+    ids = deleted
+      .map((p) => p.replace("./build/cache/gmod/", "").replace(".json", ""))
+      .filter(Boolean);
+  } catch {
+    return;
+  }
+  if (ids.length === 0) return;
+  const res = await fetch(`${base}/delete_by_ids`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ ids }),
+  });
+  if (!res.ok) console.warn(`delete_by_ids failed: ${res.status} ${await res.text()}`);
+  else console.log(`requested deletion of ${ids.length} ids`);
+}
+
+(async () => {
+  await deleteRemoved();
+  await upsertAll();
+  console.log("vectorize sync complete");
+})();

--- a/build/modules/vectorize_sync.ts
+++ b/build/modules/vectorize_sync.ts
@@ -22,7 +22,7 @@ async function upsertAll() {
     JSON.stringify({
       id: e.id,
       values: Array.from(vectors[i]),
-      metadata: { title: e.title, url: e.url, snippet: e.snippet },
+      metadata: { title: e.title, url: e.url, snippet: e.snippet, kind: e.kind },
     }),
   );
 

--- a/build/modules/workers_ai_embedder.test.ts
+++ b/build/modules/workers_ai_embedder.test.ts
@@ -17,8 +17,10 @@ describe("WorkersAiEmbedder", () => {
 
     const e = new WorkersAiEmbedder("acct", "token");
     const out = await e.embedBatch(["a", "b"]);
+
     expect(out).toHaveLength(2);
     expect(Array.from(out[0])).toEqual([expect.closeTo(0.1, 5), expect.closeTo(0.2, 5)]);
+
     expect(fetchMock).toHaveBeenCalledOnce();
     const callArgs = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
     expect(JSON.parse(callArgs[1].body)).toEqual({ text: ["a", "b"] });

--- a/build/modules/workers_ai_embedder.test.ts
+++ b/build/modules/workers_ai_embedder.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { WorkersAiEmbedder } from "./workers_ai_embedder.js";
+
+describe("WorkersAiEmbedder", () => {
+  it("throws without credentials", () => {
+    expect(() => new WorkersAiEmbedder("", "")).toThrow();
+  });
+
+  it("posts texts and parses float arrays", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ result: { data: [[0.1, 0.2], [0.3, 0.4]] }, success: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const e = new WorkersAiEmbedder("acct", "token");
+    const out = await e.embedBatch(["a", "b"]);
+    expect(out).toHaveLength(2);
+    expect(Array.from(out[0])).toEqual([expect.closeTo(0.1, 5), expect.closeTo(0.2, 5)]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const callArgs = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    expect(JSON.parse(callArgs[1].body)).toEqual({ text: ["a", "b"] });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/build/modules/workers_ai_embedder.ts
+++ b/build/modules/workers_ai_embedder.ts
@@ -1,5 +1,6 @@
 import { MODEL_ID } from "../../semantic/core/model.js";
 
+// Workers AI caps embedding requests at 100 texts per call.
 const MAX_BATCH = 100;
 
 export class WorkersAiEmbedder {
@@ -14,6 +15,7 @@ export class WorkersAiEmbedder {
 
   private async runBatch(texts: string[]): Promise<Float32Array[]> {
     const url = `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/ai/run/${MODEL_ID}`;
+
     const res = await fetch(url, {
       method: "POST",
       headers: {
@@ -22,22 +24,27 @@ export class WorkersAiEmbedder {
       },
       body: JSON.stringify({ text: texts }),
     });
+
     if (!res.ok) {
       throw new Error(`Workers AI embed failed: ${res.status} ${await res.text()}`);
     }
+
     const json: any = await res.json();
     const data: number[][] = json.result?.data;
     if (!Array.isArray(data)) throw new Error("Workers AI embed: missing result.data");
+
     return data.map((row) => Float32Array.from(row));
   }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
     const out: Float32Array[] = [];
+
     for (let i = 0; i < texts.length; i += MAX_BATCH) {
       const chunk = texts.slice(i, i + MAX_BATCH);
       out.push(...(await this.runBatch(chunk)));
       console.log(`  embedded ${Math.min(i + MAX_BATCH, texts.length)}/${texts.length}`);
     }
+
     return out;
   }
 }

--- a/build/modules/workers_ai_embedder.ts
+++ b/build/modules/workers_ai_embedder.ts
@@ -1,0 +1,43 @@
+import { MODEL_ID } from "../../semantic/core/model.js";
+
+const MAX_BATCH = 100;
+
+export class WorkersAiEmbedder {
+  constructor(
+    private accountId: string,
+    private apiToken: string,
+  ) {
+    if (!accountId || !apiToken) {
+      throw new Error("WorkersAiEmbedder requires accountId and apiToken");
+    }
+  }
+
+  private async runBatch(texts: string[]): Promise<Float32Array[]> {
+    const url = `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/ai/run/${MODEL_ID}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ text: texts }),
+    });
+    if (!res.ok) {
+      throw new Error(`Workers AI embed failed: ${res.status} ${await res.text()}`);
+    }
+    const json: any = await res.json();
+    const data: number[][] = json.result?.data;
+    if (!Array.isArray(data)) throw new Error("Workers AI embed: missing result.data");
+    return data.map((row) => Float32Array.from(row));
+  }
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    const out: Float32Array[] = [];
+    for (let i = 0; i < texts.length; i += MAX_BATCH) {
+      const chunk = texts.slice(i, i + MAX_BATCH);
+      out.push(...(await this.runBatch(chunk)));
+      console.log(`  embedded ${Math.min(i + MAX_BATCH, texts.length)}/${texts.length}`);
+    }
+    return out;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@astrojs/cloudflare": "^12.6.12",
         "@astrojs/node": "^9.5.1",
+        "@huggingface/transformers": "^3.8.1",
         "downloadjs": "^1.4.7",
         "html-to-image": "^1.11.13",
-        "vite-plugin-image-optimizer": "^2.0.3"
+        "vite-plugin-image-optimizer": "^2.0.3",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
@@ -33,6 +35,7 @@
         "sharp": "^0.34.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
+        "vitest": "^3.2.6",
         "wrangler": "^4.47.0"
       }
     },
@@ -899,9 +902,29 @@
         "url": "https://buymeacoffee.com/frsource"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1022,7 +1045,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1039,7 +1061,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1164,7 +1185,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1187,7 +1207,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1317,7 +1336,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1366,6 +1384,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2329,6 +2359,63 @@
       "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
       "license": "MIT"
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -2787,6 +2874,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/clean-css": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.11.tgz",
@@ -2823,6 +2921,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2946,6 +3051,121 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@volar/kit": {
       "version": "2.4.27",
@@ -3238,6 +3458,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astro": {
       "version": "5.16.3",
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.3.tgz",
@@ -3382,6 +3612,13 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -3459,6 +3696,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -3529,6 +3776,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "license": "MIT",
@@ -3586,6 +3850,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/cheerio": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -3641,6 +3915,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -4099,6 +4382,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -4117,6 +4410,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -4147,6 +4474,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/deterministic-object-hash": {
       "version": "2.0.2",
@@ -4346,8 +4679,32 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
+      "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -4865,6 +5222,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "license": "MIT"
@@ -4958,6 +5325,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -5077,6 +5450,39 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gmod-wiki-scraper": {
       "version": "2.0.0-rc.1",
       "resolved": "git+ssh://git@github.com/NullEnt1ty/gmod-wiki-scraper.git#8ac67d34d8e2f9be3894672445be4d4a612d3761",
@@ -5096,6 +5502,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/got": {
@@ -5124,6 +5542,12 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/h3": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.4.tgz",
@@ -5139,6 +5563,18 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.1",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -5659,6 +6095,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -5684,6 +6127,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/jsonc-parser": {
       "version": "2.3.1",
@@ -5728,7 +6177,6 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -5760,7 +6208,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5781,7 +6228,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5802,7 +6248,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5823,7 +6268,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5844,7 +6288,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5865,7 +6308,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5886,7 +6328,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5907,7 +6348,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5928,7 +6368,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5949,7 +6388,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5970,7 +6408,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5991,6 +6428,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -6000,6 +6443,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -6065,6 +6515,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -7042,6 +7516,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "license": "MIT",
@@ -7151,6 +7646,15 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -7212,6 +7716,49 @@
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
@@ -7383,6 +7930,16 @@
       "version": "2.0.3",
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -7467,6 +8024,12 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
     },
     "node_modules/postcss": {
@@ -7572,6 +8135,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pump": {
@@ -7973,6 +8559,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.52.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
@@ -8100,6 +8703,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
     "node_modules/send": {
       "version": "1.2.0",
       "license": "MIT",
@@ -8132,6 +8741,33 @@
         "upper-case-first": "^2.0.2"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/server-destroy": {
       "version": "1.0.1",
       "license": "ISC"
@@ -8144,7 +8780,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -8193,7 +8828,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8216,7 +8850,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8239,7 +8872,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8256,7 +8888,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8273,7 +8904,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8290,7 +8920,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8307,7 +8936,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8324,7 +8952,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8341,7 +8968,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8358,7 +8984,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8375,7 +9000,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8398,7 +9022,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8421,7 +9044,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8444,7 +9066,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8467,7 +9088,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8490,7 +9110,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8513,7 +9132,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -8533,7 +9151,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8553,7 +9170,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8581,6 +9197,13 @@
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
@@ -8675,12 +9298,32 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
@@ -8755,6 +9398,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -8802,6 +9458,22 @@
         "node": ">=16"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/terser": {
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
@@ -8842,6 +9514,13 @@
       "version": "1.0.3",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -8863,6 +9542,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9451,6 +10160,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-image-optimizer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vite-plugin-image-optimizer/-/vite-plugin-image-optimizer-2.0.3.tgz",
@@ -9493,6 +10225,86 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/volar-service-css": {
       "version": "0.0.67",
@@ -9787,6 +10599,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/widest-line": {
       "version": "5.0.0",
       "license": "MIT",
@@ -9950,6 +10779,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yaml": {
@@ -10146,6 +10984,8 @@
     },
     "node_modules/zod": {
       "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,14 @@
     "upload_categories": "/bin/bash ./build/modules/categories/upload_categories.sh",
     "build_categories": "node --no-warnings=ExperimentalWarning --trace-uncaught --trace-warnings --loader ts-node/esm ./build/modules/categories/build_categories.ts",
     "clear_recent_changes": "node --no-warnings=ExperimentalWarning --trace-uncaught --trace-warnings --loader ts-node/esm ./build/modules/clear_recent_changes.ts",
-    "clear_cloudflare_cache": "node --no-warnings=ExperimentalWarning --trace-uncaught --trace-warnings --loader ts-node/esm ./build/modules/clear_cloudflare_cache.ts"
+    "clear_cloudflare_cache": "node --no-warnings=ExperimentalWarning --trace-uncaught --trace-warnings --loader ts-node/esm ./build/modules/clear_cloudflare_cache.ts",
+    "vectorize_sync": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ./build/modules/vectorize_sync.ts",
+    "embeddings": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ./build/build_embeddings_local.ts",
+    "embeddings:publish": "npm run embeddings && npm run vectorize_sync",
+    "mcp:deploy": "npm --prefix semantic/mcp/hosted run deploy",
+    "mcp:publish": "npm run embeddings:publish && npm run mcp:deploy",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
@@ -36,13 +43,16 @@
     "sharp": "^0.34.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
+    "vitest": "^3.2.6",
     "wrangler": "^4.47.0"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.12",
     "@astrojs/node": "^9.5.1",
+    "@huggingface/transformers": "^3.8.1",
     "downloadjs": "^1.4.7",
     "html-to-image": "^1.11.13",
-    "vite-plugin-image-optimizer": "^2.0.3"
+    "vite-plugin-image-optimizer": "^2.0.3",
+    "zod": "^3.25.76"
   }
 }

--- a/semantic/adapters/hosted/embedder.ts
+++ b/semantic/adapters/hosted/embedder.ts
@@ -1,0 +1,13 @@
+import { MODEL_ID, QUERY_PREFIX } from "../../core/model.js";
+import type { Embedder } from "../../core/types.js";
+
+export class HostedEmbedder implements Embedder {
+  constructor(private ai: Ai) {}
+
+  async embed(text: string): Promise<Float32Array> {
+    const res: any = await this.ai.run(MODEL_ID as any, { text: [QUERY_PREFIX + text] });
+    const data: number[][] = res.data ?? res.result?.data;
+    if (!data || !data[0]) throw new Error("Workers AI embed returned no data");
+    return Float32Array.from(data[0]);
+  }
+}

--- a/semantic/adapters/hosted/embedder.ts
+++ b/semantic/adapters/hosted/embedder.ts
@@ -5,9 +5,12 @@ export class HostedEmbedder implements Embedder {
   constructor(private ai: Ai) {}
 
   async embed(text: string): Promise<Float32Array> {
+    // bge is asymmetric: documents are embedded bare, queries need QUERY_PREFIX.
     const res: any = await this.ai.run(MODEL_ID as any, { text: [QUERY_PREFIX + text] });
+
     const data: number[][] = res.data ?? res.result?.data;
     if (!data || !data[0]) throw new Error("Workers AI embed returned no data");
+
     return Float32Array.from(data[0]);
   }
 }

--- a/semantic/adapters/hosted/store.ts
+++ b/semantic/adapters/hosted/store.ts
@@ -5,6 +5,7 @@ export class HostedVectorStore implements VectorStore {
 
   async query(vector: Float32Array, k: number): Promise<Match[]> {
     const res = await this.index.query(Array.from(vector), { topK: k, returnMetadata: "all" });
+
     return res.matches.map((m) => ({
       id: m.id,
       score: m.score,

--- a/semantic/adapters/hosted/store.ts
+++ b/semantic/adapters/hosted/store.ts
@@ -1,4 +1,4 @@
-import type { Match, VectorStore } from "../../core/types.js";
+import type { Match, PageKind, VectorStore } from "../../core/types.js";
 
 export class HostedVectorStore implements VectorStore {
   constructor(private index: VectorizeIndex) {}
@@ -8,7 +8,7 @@ export class HostedVectorStore implements VectorStore {
     return res.matches.map((m) => ({
       id: m.id,
       score: m.score,
-      metadata: m.metadata as { title: string; url: string; snippet: string } | undefined,
+      metadata: m.metadata as { title: string; url: string; snippet: string; kind?: PageKind } | undefined,
     }));
   }
 }

--- a/semantic/adapters/hosted/store.ts
+++ b/semantic/adapters/hosted/store.ts
@@ -1,0 +1,14 @@
+import type { Match, VectorStore } from "../../core/types.js";
+
+export class HostedVectorStore implements VectorStore {
+  constructor(private index: VectorizeIndex) {}
+
+  async query(vector: Float32Array, k: number): Promise<Match[]> {
+    const res = await this.index.query(Array.from(vector), { topK: k, returnMetadata: "all" });
+    return res.matches.map((m) => ({
+      id: m.id,
+      score: m.score,
+      metadata: m.metadata as { title: string; url: string; snippet: string } | undefined,
+    }));
+  }
+}

--- a/semantic/adapters/local/embedder.ts
+++ b/semantic/adapters/local/embedder.ts
@@ -7,17 +7,11 @@ export class LocalEmbedder implements Embedder {
 
   private async ensure() {
     if (!this.extractor) {
-      // Node uses the onnxruntime-node (cpu) backend — the only one transformers.js
-      // supports outside the browser. The Docker image prunes the unused
-      // cross-platform binaries to keep the size down (packaging strategy A).
-      // q8 keeps the baked model ~35MB (vs ~90MB fp32); negligible cosine-rank impact.
-      //
-      // MODEL_CACHE_DIR: set in the Docker final image to the baked-in hf-cache path.
-      // When present, force offline mode so the container never hits the network.
       if (process.env.MODEL_CACHE_DIR) {
         env.cacheDir = process.env.MODEL_CACHE_DIR;
         env.allowRemoteModels = false;
       }
+
       this.extractor = await pipeline("feature-extraction", "Xenova/bge-base-en-v1.5", {
         dtype: "q8",
       });

--- a/semantic/adapters/local/embedder.ts
+++ b/semantic/adapters/local/embedder.ts
@@ -7,21 +7,29 @@ export class LocalEmbedder implements Embedder {
 
   private async ensure() {
     if (!this.extractor) {
+      // When a pre-baked model cache is provided, use it and never hit the network.
       if (process.env.MODEL_CACHE_DIR) {
         env.cacheDir = process.env.MODEL_CACHE_DIR;
         env.allowRemoteModels = false;
       }
 
+      // Same model the build embeds documents with. q8 = 8-bit quantized
+      // weights: smaller download, faster CPU inference, negligible quality loss.
       this.extractor = await pipeline("feature-extraction", "Xenova/bge-base-en-v1.5", {
         dtype: "q8",
       });
     }
+
     return this.extractor;
   }
 
   async embed(text: string): Promise<Float32Array> {
     const extractor = await this.ensure();
+
+    // Mean pooling + normalization matches how Workers AI serves this model,
+    // so local and hosted scores are comparable.
     const output = await extractor(QUERY_PREFIX + text, { pooling: "mean", normalize: true });
+
     return Float32Array.from(output.data as Float32Array);
   }
 }

--- a/semantic/adapters/local/embedder.ts
+++ b/semantic/adapters/local/embedder.ts
@@ -1,0 +1,33 @@
+import { pipeline, env } from "@huggingface/transformers";
+import type { Embedder } from "../../core/types.js";
+import { QUERY_PREFIX } from "../../core/model.js";
+
+export class LocalEmbedder implements Embedder {
+  private extractor: any | null = null;
+
+  private async ensure() {
+    if (!this.extractor) {
+      // Node uses the onnxruntime-node (cpu) backend — the only one transformers.js
+      // supports outside the browser. The Docker image prunes the unused
+      // cross-platform binaries to keep the size down (packaging strategy A).
+      // q8 keeps the baked model ~35MB (vs ~90MB fp32); negligible cosine-rank impact.
+      //
+      // MODEL_CACHE_DIR: set in the Docker final image to the baked-in hf-cache path.
+      // When present, force offline mode so the container never hits the network.
+      if (process.env.MODEL_CACHE_DIR) {
+        env.cacheDir = process.env.MODEL_CACHE_DIR;
+        env.allowRemoteModels = false;
+      }
+      this.extractor = await pipeline("feature-extraction", "Xenova/bge-base-en-v1.5", {
+        dtype: "q8",
+      });
+    }
+    return this.extractor;
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    const extractor = await this.ensure();
+    const output = await extractor(QUERY_PREFIX + text, { pooling: "mean", normalize: true });
+    return Float32Array.from(output.data as Float32Array);
+  }
+}

--- a/semantic/adapters/local/store.test.ts
+++ b/semantic/adapters/local/store.test.ts
@@ -18,8 +18,8 @@ beforeAll(async () => {
   const manifest: Manifest = {
     model: "m", dims: 3, count: 2,
     entries: [
-      { id: "A", address: "A", title: "Alpha", snippet: "a", url: "/A", changeKey: "1" },
-      { id: "B", address: "B", title: "Beta", snippet: "b", url: "/B", changeKey: "1" },
+      { id: "A", address: "A", title: "Alpha", snippet: "a", url: "/A", kind: "function", changeKey: "1" },
+      { id: "B", address: "B", title: "Beta", snippet: "b", url: "/B", kind: "hook", changeKey: "1" },
     ],
   };
   await fs.writeFile(manifestPath, JSON.stringify(manifest));
@@ -30,6 +30,6 @@ describe("LocalVectorStore", () => {
     const store = await LocalVectorStore.load(binPath, manifestPath);
     const matches = await store.query(new Float32Array([1, 0, 0]), 1);
     expect(matches[0].id).toBe("A");
-    expect(matches[0].metadata).toEqual({ title: "Alpha", url: "/A", snippet: "a" });
+    expect(matches[0].metadata).toEqual({ title: "Alpha", url: "/A", snippet: "a", kind: "function" });
   });
 });

--- a/semantic/adapters/local/store.test.ts
+++ b/semantic/adapters/local/store.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { encodeEmbeddings } from "../../core/binary.js";
+import { LocalVectorStore } from "./store.js";
+import type { Manifest } from "../../core/types.js";
+
+let binPath: string;
+let manifestPath: string;
+
+beforeAll(async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "lvs-"));
+  binPath = path.join(tmp, "embeddings.bin");
+  manifestPath = path.join(tmp, "manifest.json");
+  const vectors = [new Float32Array([1, 0, 0]), new Float32Array([0, 1, 0])];
+  await fs.writeFile(binPath, encodeEmbeddings(vectors, 3));
+  const manifest: Manifest = {
+    model: "m", dims: 3, count: 2,
+    entries: [
+      { id: "A", address: "A", title: "Alpha", snippet: "a", url: "/A", changeKey: "1" },
+      { id: "B", address: "B", title: "Beta", snippet: "b", url: "/B", changeKey: "1" },
+    ],
+  };
+  await fs.writeFile(manifestPath, JSON.stringify(manifest));
+});
+
+describe("LocalVectorStore", () => {
+  it("returns the nearest id with metadata", async () => {
+    const store = await LocalVectorStore.load(binPath, manifestPath);
+    const matches = await store.query(new Float32Array([1, 0, 0]), 1);
+    expect(matches[0].id).toBe("A");
+    expect(matches[0].metadata).toEqual({ title: "Alpha", url: "/A", snippet: "a" });
+  });
+});

--- a/semantic/adapters/local/store.test.ts
+++ b/semantic/adapters/local/store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { promises as fs } from "fs";
 import os from "os";
 import path from "path";
+
 import { encodeEmbeddings } from "../../core/binary.js";
 import { LocalVectorStore } from "./store.js";
 import type { Manifest } from "../../core/types.js";
@@ -13,8 +14,10 @@ beforeAll(async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "lvs-"));
   binPath = path.join(tmp, "embeddings.bin");
   manifestPath = path.join(tmp, "manifest.json");
+
   const vectors = [new Float32Array([1, 0, 0]), new Float32Array([0, 1, 0])];
   await fs.writeFile(binPath, encodeEmbeddings(vectors, 3));
+
   const manifest: Manifest = {
     model: "m", dims: 3, count: 2,
     entries: [
@@ -29,6 +32,7 @@ describe("LocalVectorStore", () => {
   it("returns the nearest id with metadata", async () => {
     const store = await LocalVectorStore.load(binPath, manifestPath);
     const matches = await store.query(new Float32Array([1, 0, 0]), 1);
+
     expect(matches[0].id).toBe("A");
     expect(matches[0].metadata).toEqual({ title: "Alpha", url: "/A", snippet: "a", kind: "function" });
   });

--- a/semantic/adapters/local/store.ts
+++ b/semantic/adapters/local/store.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import { decodeEmbeddings } from "../../core/binary.js";
 import { bruteForceTopK } from "../../core/cosine.js";
-import type { Manifest, Match, VectorStore } from "../../core/types.js";
+import type { Manifest, Match, PageKind, VectorStore } from "../../core/types.js";
 
 export class LocalVectorStore implements VectorStore {
   private constructor(
@@ -17,9 +17,9 @@ export class LocalVectorStore implements VectorStore {
     return new LocalVectorStore(vectors, ids, manifest);
   }
 
-  meta(id: string): { title: string; url: string; snippet: string } | null {
+  meta(id: string): { title: string; url: string; snippet: string; kind?: PageKind } | null {
     const e = this.manifest.entries.find((x) => x.id === id);
-    return e ? { title: e.title, url: e.url, snippet: e.snippet } : null;
+    return e ? { title: e.title, url: e.url, snippet: e.snippet, kind: e.kind } : null;
   }
 
   async query(vector: Float32Array, k: number): Promise<Match[]> {

--- a/semantic/adapters/local/store.ts
+++ b/semantic/adapters/local/store.ts
@@ -13,7 +13,10 @@ export class LocalVectorStore implements VectorStore {
   static async load(binPath: string, manifestPath: string): Promise<LocalVectorStore> {
     const manifest: Manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
     const { vectors } = decodeEmbeddings(new Uint8Array(await fs.readFile(binPath)));
+
+    // Manifest entries and binary vectors are parallel arrays, same order.
     const ids = manifest.entries.map((e) => e.id);
+
     return new LocalVectorStore(vectors, ids, manifest);
   }
 

--- a/semantic/adapters/local/store.ts
+++ b/semantic/adapters/local/store.ts
@@ -1,0 +1,29 @@
+import { promises as fs } from "fs";
+import { decodeEmbeddings } from "../../core/binary.js";
+import { bruteForceTopK } from "../../core/cosine.js";
+import type { Manifest, Match, VectorStore } from "../../core/types.js";
+
+export class LocalVectorStore implements VectorStore {
+  private constructor(
+    private vectors: Float32Array[],
+    private ids: string[],
+    private manifest: Manifest,
+  ) {}
+
+  static async load(binPath: string, manifestPath: string): Promise<LocalVectorStore> {
+    const manifest: Manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+    const { vectors } = decodeEmbeddings(new Uint8Array(await fs.readFile(binPath)));
+    const ids = manifest.entries.map((e) => e.id);
+    return new LocalVectorStore(vectors, ids, manifest);
+  }
+
+  meta(id: string): { title: string; url: string; snippet: string } | null {
+    const e = this.manifest.entries.find((x) => x.id === id);
+    return e ? { title: e.title, url: e.url, snippet: e.snippet } : null;
+  }
+
+  async query(vector: Float32Array, k: number): Promise<Match[]> {
+    const top = bruteForceTopK(vector, this.vectors, this.ids, k);
+    return top.map((m) => ({ ...m, metadata: this.meta(m.id) ?? undefined }));
+  }
+}

--- a/semantic/core/binary.test.ts
+++ b/semantic/core/binary.test.ts
@@ -4,13 +4,16 @@ import { encodeEmbeddings, decodeEmbeddings } from "./binary.js";
 describe("embeddings codec", () => {
   it("round-trips vectors", () => {
     const vectors = [new Float32Array([0.1, 0.2, 0.3]), new Float32Array([0.4, 0.5, 0.6])];
+
     const decoded = decodeEmbeddings(encodeEmbeddings(vectors, 3));
+
     expect(decoded.dims).toBe(3);
     expect(decoded.count).toBe(2);
     expect(Array.from(decoded.vectors[1])).toEqual(expect.arrayContaining([
       expect.closeTo(0.4, 5), expect.closeTo(0.5, 5), expect.closeTo(0.6, 5),
     ]));
   });
+
   it("rejects a buffer with the wrong magic", () => {
     expect(() => decodeEmbeddings(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))).toThrow();
   });

--- a/semantic/core/binary.test.ts
+++ b/semantic/core/binary.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { encodeEmbeddings, decodeEmbeddings } from "./binary.js";
+
+describe("embeddings codec", () => {
+  it("round-trips vectors", () => {
+    const vectors = [new Float32Array([0.1, 0.2, 0.3]), new Float32Array([0.4, 0.5, 0.6])];
+    const decoded = decodeEmbeddings(encodeEmbeddings(vectors, 3));
+    expect(decoded.dims).toBe(3);
+    expect(decoded.count).toBe(2);
+    expect(Array.from(decoded.vectors[1])).toEqual(expect.arrayContaining([
+      expect.closeTo(0.4, 5), expect.closeTo(0.5, 5), expect.closeTo(0.6, 5),
+    ]));
+  });
+  it("rejects a buffer with the wrong magic", () => {
+    expect(() => decodeEmbeddings(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))).toThrow();
+  });
+});

--- a/semantic/core/binary.ts
+++ b/semantic/core/binary.ts
@@ -1,0 +1,36 @@
+const MAGIC = 0x474d5745; // "GMWE"
+const HEADER_BYTES = 12;
+
+export function encodeEmbeddings(vectors: Float32Array[], dims: number): Uint8Array {
+  const count = vectors.length;
+  const buf = new ArrayBuffer(HEADER_BYTES + count * dims * 4);
+  const view = new DataView(buf);
+  view.setUint32(0, MAGIC, true);
+  view.setUint32(4, dims, true);
+  view.setUint32(8, count, true);
+  const floats = new Float32Array(buf, HEADER_BYTES);
+  for (let i = 0; i < count; i++) {
+    if (vectors[i].length !== dims) {
+      throw new Error(`vector ${i} has length ${vectors[i].length}, expected ${dims}`);
+    }
+    floats.set(vectors[i], i * dims);
+  }
+  return new Uint8Array(buf);
+}
+
+export function decodeEmbeddings(buf: Uint8Array): {
+  dims: number;
+  count: number;
+  vectors: Float32Array[];
+} {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  if (view.getUint32(0, true) !== MAGIC) throw new Error("bad embeddings magic");
+  const dims = view.getUint32(4, true);
+  const count = view.getUint32(8, true);
+  const vectors: Float32Array[] = [];
+  for (let i = 0; i < count; i++) {
+    const start = buf.byteOffset + HEADER_BYTES + i * dims * 4;
+    vectors.push(new Float32Array(buf.buffer.slice(start, start + dims * 4)));
+  }
+  return { dims, count, vectors };
+}

--- a/semantic/core/binary.ts
+++ b/semantic/core/binary.ts
@@ -1,13 +1,18 @@
+// Flat binary format for the embedding matrix:
+// uint32 magic | uint32 dims | uint32 count (all LE), then count * dims float32s.
+
 const MAGIC = 0x474d5745; // "GMWE"
 const HEADER_BYTES = 12;
 
 export function encodeEmbeddings(vectors: Float32Array[], dims: number): Uint8Array {
   const count = vectors.length;
   const buf = new ArrayBuffer(HEADER_BYTES + count * dims * 4);
+
   const view = new DataView(buf);
   view.setUint32(0, MAGIC, true);
   view.setUint32(4, dims, true);
   view.setUint32(8, count, true);
+
   const floats = new Float32Array(buf, HEADER_BYTES);
   for (let i = 0; i < count; i++) {
     if (vectors[i].length !== dims) {
@@ -15,6 +20,7 @@ export function encodeEmbeddings(vectors: Float32Array[], dims: number): Uint8Ar
     }
     floats.set(vectors[i], i * dims);
   }
+
   return new Uint8Array(buf);
 }
 
@@ -25,12 +31,15 @@ export function decodeEmbeddings(buf: Uint8Array): {
 } {
   const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
   if (view.getUint32(0, true) !== MAGIC) throw new Error("bad embeddings magic");
+
   const dims = view.getUint32(4, true);
   const count = view.getUint32(8, true);
+
   const vectors: Float32Array[] = [];
   for (let i = 0; i < count; i++) {
     const start = buf.byteOffset + HEADER_BYTES + i * dims * 4;
     vectors.push(new Float32Array(buf.buffer.slice(start, start + dims * 4)));
   }
+
   return { dims, count, vectors };
 }

--- a/semantic/core/cosine.test.ts
+++ b/semantic/core/cosine.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { cosineSimilarity, bruteForceTopK } from "./cosine.js";
+
+describe("cosineSimilarity", () => {
+  it("is 1 for identical vectors", () => {
+    const v = new Float32Array([1, 2, 3]);
+    expect(cosineSimilarity(v, new Float32Array([1, 2, 3]))).toBeCloseTo(1, 5);
+  });
+  it("is 0 for orthogonal vectors", () => {
+    expect(cosineSimilarity(new Float32Array([1, 0]), new Float32Array([0, 1]))).toBeCloseTo(0, 5);
+  });
+});
+
+describe("bruteForceTopK", () => {
+  it("returns the closest ids in descending score order", () => {
+    const vectors = [
+      new Float32Array([1, 0]),
+      new Float32Array([0.9, 0.1]),
+      new Float32Array([0, 1]),
+    ];
+    const ids = ["a", "b", "c"];
+    const out = bruteForceTopK(new Float32Array([1, 0]), vectors, ids, 2);
+    expect(out.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(out[0].score).toBeGreaterThanOrEqual(out[1].score);
+  });
+});

--- a/semantic/core/cosine.test.ts
+++ b/semantic/core/cosine.test.ts
@@ -6,6 +6,7 @@ describe("cosineSimilarity", () => {
     const v = new Float32Array([1, 2, 3]);
     expect(cosineSimilarity(v, new Float32Array([1, 2, 3]))).toBeCloseTo(1, 5);
   });
+
   it("is 0 for orthogonal vectors", () => {
     expect(cosineSimilarity(new Float32Array([1, 0]), new Float32Array([0, 1]))).toBeCloseTo(0, 5);
   });
@@ -19,7 +20,9 @@ describe("bruteForceTopK", () => {
       new Float32Array([0, 1]),
     ];
     const ids = ["a", "b", "c"];
+
     const out = bruteForceTopK(new Float32Array([1, 0]), vectors, ids, 2);
+
     expect(out.map((m) => m.id)).toEqual(["a", "b"]);
     expect(out[0].score).toBeGreaterThanOrEqual(out[1].score);
   });

--- a/semantic/core/cosine.ts
+++ b/semantic/core/cosine.ts
@@ -1,0 +1,28 @@
+import type { Match } from "./types.js";
+
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+export function bruteForceTopK(
+  query: Float32Array,
+  vectors: Float32Array[],
+  ids: string[],
+  k: number,
+): Match[] {
+  const scored: Match[] = vectors.map((v, i) => ({
+    id: ids[i],
+    score: cosineSimilarity(query, v),
+  }));
+  scored.sort((x, y) => y.score - x.score);
+  return scored.slice(0, k);
+}

--- a/semantic/core/cosine.ts
+++ b/semantic/core/cosine.ts
@@ -4,15 +4,20 @@ export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   let dot = 0;
   let na = 0;
   let nb = 0;
+
   for (let i = 0; i < a.length; i++) {
     dot += a[i] * b[i];
     na += a[i] * a[i];
     nb += b[i] * b[i];
   }
+
   if (na === 0 || nb === 0) return 0;
+
   return dot / (Math.sqrt(na) * Math.sqrt(nb));
 }
 
+// Exact linear scan. Fast enough at wiki scale (a few thousand vectors),
+// so no ANN index is needed.
 export function bruteForceTopK(
   query: Float32Array,
   vectors: Float32Array[],
@@ -23,6 +28,8 @@ export function bruteForceTopK(
     id: ids[i],
     score: cosineSimilarity(query, v),
   }));
+
   scored.sort((x, y) => y.score - x.score);
+
   return scored.slice(0, k);
 }

--- a/semantic/core/embed-text.test.ts
+++ b/semantic/core/embed-text.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { extractPlainText, buildEmbedText, buildSnippet } from "./embed-text.js";
+import type { RawEntry } from "./types.js";
+
+const entry: RawEntry = {
+  address: "Player:Say",
+  title: "Player:Say",
+  tags: "function method member realm-server",
+  html: "<div><h1>Description</h1><p>Forces the player to say whatever the first argument is.</p><script>ignore()</script></div>",
+  revisionId: 565243,
+};
+
+describe("extractPlainText", () => {
+  it("strips tags and scripts", () => {
+    const t = extractPlainText(entry.html);
+    expect(t).toContain("Forces the player to say");
+    expect(t).not.toContain("ignore()");
+    expect(t).not.toContain("<");
+  });
+});
+
+describe("buildEmbedText", () => {
+  it("leads with the title and tag words, then the body", () => {
+    const t = buildEmbedText(entry);
+    expect(t.startsWith("Player:Say")).toBe(true);
+    expect(t).toContain("function");
+    expect(t).toContain("Forces the player to say");
+  });
+
+  it("truncates to <= 1800 chars", () => {
+    const big: RawEntry = { ...entry, html: "<p>" + "word ".repeat(2000) + "</p>" };
+    expect(buildEmbedText(big).length).toBeLessThanOrEqual(1800);
+  });
+});
+
+describe("buildSnippet", () => {
+  it("returns a short plain preview", () => {
+    const s = buildSnippet(entry, 40);
+    expect(s.length).toBeLessThanOrEqual(43); // 40 + possible "..."
+    expect(s).toContain("Forces the player");
+  });
+});

--- a/semantic/core/embed-text.test.ts
+++ b/semantic/core/embed-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractPlainText, buildEmbedText, buildSnippet } from "./embed-text.js";
+import { extractPlainText, buildEmbedText, buildSnippet, kindFor } from "./embed-text.js";
 import type { RawEntry } from "./types.js";
 
 const entry: RawEntry = {
@@ -31,6 +31,51 @@ describe("buildEmbedText", () => {
     const big: RawEntry = { ...entry, html: "<p>" + "word ".repeat(2000) + "</p>" };
     expect(buildEmbedText(big).length).toBeLessThanOrEqual(1800);
   });
+
+  it("extracts typed args from markup and strips warning URLs", () => {
+    const withMarkup: RawEntry = {
+      ...entry,
+      markup: `<function name="Say" parent="Player" type="classfunc">
+        <description>Forces the player to say something.
+          <warning>Max 126 chars. [Source](https://github.com/x/y/client.cpp#L84)</warning>
+        </description>
+        <realm>Server</realm>
+        <args>
+          <arg name="text" type="string">The text to say.</arg>
+          <arg name="teamOnly" type="boolean" default="false">Team only.</arg>
+        </args>
+      </function>`,
+    };
+    const t = buildEmbedText(withMarkup);
+    expect(t).toContain("text (string): The text to say.");
+    expect(t).toContain("teamOnly (boolean): Team only.");
+    expect(t).toContain("Server");
+    expect(t).not.toContain("github.com"); // URL stripped
+    expect(t).toContain("Source"); // link label kept
+  });
+
+  it("falls back to HTML when markup has no <function>", () => {
+    const cat: RawEntry = { ...entry, markup: "<cat>2D Rendering</cat>" };
+    expect(buildEmbedText(cat)).toContain("Forces the player to say");
+  });
+});
+
+describe("kindFor", () => {
+  const k = (markup?: string) => kindFor({ ...entry, markup });
+  it("classifies callable functions", () => {
+    expect(k(`<function type="classfunc"></function>`)).toBe("function");
+    expect(k(`<function type="libraryfunc"></function>`)).toBe("function");
+    expect(k(`<function type="panelfunc"></function>`)).toBe("function");
+  });
+  it("classifies hooks", () => {
+    expect(k(`<function type="hook"></function>`)).toBe("hook");
+    expect(k(`<function type="panelhook"></function>`)).toBe("hook");
+  });
+  it("treats enums/categories and markup-less pages as other", () => {
+    expect(k(`<enum></enum>`)).toBe("other");
+    expect(k(`<cat>2D Rendering</cat>`)).toBe("other");
+    expect(k(undefined)).toBe("other");
+  });
 });
 
 describe("buildSnippet", () => {
@@ -38,5 +83,20 @@ describe("buildSnippet", () => {
     const s = buildSnippet(entry, 40);
     expect(s.length).toBeLessThanOrEqual(43); // 40 + possible "..."
     expect(s).toContain("Forces the player");
+  });
+
+  it("uses the markup description, omitting signature/Search Github/Description", () => {
+    const withMarkup: RawEntry = {
+      ...entry,
+      html: "<div>Entity:TakeDamage( number damageAmount ) Search Github Description Applies damage.</div>",
+      markup: `<function name="TakeDamage" parent="Entity" type="classfunc">
+        <description>Applies the specified amount of damage to the entity.</description>
+        <realm>Shared</realm>
+      </function>`,
+    };
+    const s = buildSnippet(withMarkup);
+    expect(s).toBe("Applies the specified amount of damage to the entity.");
+    expect(s).not.toContain("Search Github");
+    expect(s).not.toContain("Description");
   });
 });

--- a/semantic/core/embed-text.test.ts
+++ b/semantic/core/embed-text.test.ts
@@ -13,6 +13,7 @@ const entry: RawEntry = {
 describe("extractPlainText", () => {
   it("strips tags and scripts", () => {
     const t = extractPlainText(entry.html);
+
     expect(t).toContain("Forces the player to say");
     expect(t).not.toContain("ignore()");
     expect(t).not.toContain("<");
@@ -22,6 +23,7 @@ describe("extractPlainText", () => {
 describe("buildEmbedText", () => {
   it("leads with the title and tag words, then the body", () => {
     const t = buildEmbedText(entry);
+
     expect(t.startsWith("Player:Say")).toBe(true);
     expect(t).toContain("function");
     expect(t).toContain("Forces the player to say");
@@ -46,7 +48,9 @@ describe("buildEmbedText", () => {
         </args>
       </function>`,
     };
+
     const t = buildEmbedText(withMarkup);
+
     expect(t).toContain("text (string): The text to say.");
     expect(t).toContain("teamOnly (boolean): Team only.");
     expect(t).toContain("Server");
@@ -62,15 +66,18 @@ describe("buildEmbedText", () => {
 
 describe("kindFor", () => {
   const k = (markup?: string) => kindFor({ ...entry, markup });
+
   it("classifies callable functions", () => {
     expect(k(`<function type="classfunc"></function>`)).toBe("function");
     expect(k(`<function type="libraryfunc"></function>`)).toBe("function");
     expect(k(`<function type="panelfunc"></function>`)).toBe("function");
   });
+
   it("classifies hooks", () => {
     expect(k(`<function type="hook"></function>`)).toBe("hook");
     expect(k(`<function type="panelhook"></function>`)).toBe("hook");
   });
+
   it("treats enums/categories and markup-less pages as other", () => {
     expect(k(`<enum></enum>`)).toBe("other");
     expect(k(`<cat>2D Rendering</cat>`)).toBe("other");
@@ -81,6 +88,7 @@ describe("kindFor", () => {
 describe("buildSnippet", () => {
   it("returns a short plain preview", () => {
     const s = buildSnippet(entry, 40);
+
     expect(s.length).toBeLessThanOrEqual(43); // 40 + possible "..."
     expect(s).toContain("Forces the player");
   });
@@ -94,7 +102,9 @@ describe("buildSnippet", () => {
         <realm>Shared</realm>
       </function>`,
     };
+
     const s = buildSnippet(withMarkup);
+
     expect(s).toBe("Applies the specified amount of damage to the entity.");
     expect(s).not.toContain("Search Github");
     expect(s).not.toContain("Description");

--- a/semantic/core/embed-text.ts
+++ b/semantic/core/embed-text.ts
@@ -1,0 +1,30 @@
+import * as cheerio from "cheerio";
+import type { RawEntry } from "./types.js";
+
+const MAX_EMBED_CHARS = 1800;
+
+export function extractPlainText(html: string): string {
+  const $ = cheerio.load(html);
+  $("script, style").remove();
+  $("br").replaceWith("\n");
+  const text = $.root().text();
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function buildEmbedText(entry: RawEntry): string {
+  const tagWords = (entry.tags || "").replace(/[-_]/g, " ").trim();
+  const body = extractPlainText(entry.html || "");
+  const combined = [entry.title, tagWords, body]
+    .filter((p) => p && p.length > 0)
+    .join(". ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return combined.slice(0, MAX_EMBED_CHARS);
+}
+
+export function buildSnippet(entry: RawEntry, maxLen = 200): string {
+  const body = extractPlainText(entry.html || "");
+  if (body.length <= maxLen) return body;
+  const cut = body.lastIndexOf(" ", maxLen);
+  return body.slice(0, cut > 0 ? cut : maxLen) + "...";
+}

--- a/semantic/core/embed-text.ts
+++ b/semantic/core/embed-text.ts
@@ -1,35 +1,40 @@
 import * as cheerio from "cheerio";
 import type { PageKind, RawEntry } from "./types.js";
 
+// Cap on embedded text, sized to the model's input window.
 const MAX_EMBED_CHARS = 1800;
 
 const FUNCTION_TYPES = new Set(["classfunc", "libraryfunc", "panelfunc"]);
 const HOOK_TYPES = new Set(["hook", "panelhook"]);
 
 /**
- * Classify a page from its markup `<function type="...">` attribute. Callable
- * functions and event hooks are distinguished so ranking can prefer functions
- * for action queries; everything else (enums, structs, categories, panels) is
- * `other`. Pages without function markup are `other`.
+ * Classify a page from its markup `<function type="...">` attribute.
+ * Callable functions and event hooks are distinguished so ranking can prefer
+ * functions for action queries; everything else (enums, structs, categories,
+ * panels, markup-less pages) is `other`.
  */
 export function kindFor(entry: RawEntry): PageKind {
   const t = entry.markup?.match(/<function[^>]*\btype="([^"]+)"/)?.[1];
+
   if (t && FUNCTION_TYPES.has(t)) return "function";
   if (t && HOOK_TYPES.has(t)) return "hook";
+
   return "other";
 }
 
 export function extractPlainText(html: string): string {
   const $ = cheerio.load(html);
+
   $("script, style").remove();
   $(".function_links").remove(); // drops the "Search Github" link
   $("br").replaceWith("\n");
+
   const text = $.root().text();
   return text.replace(/\s+/g, " ").trim();
 }
 
-// Drop markdown links and bare URLs (notes/warnings embed source links that are
-// noise for retrieval), then collapse whitespace.
+// Drop markdown links and bare URLs (notes/warnings embed source links that
+// are noise for retrieval), then collapse whitespace.
 function clean(s: string): string {
   return s
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
@@ -39,24 +44,26 @@ function clean(s: string): string {
 }
 
 /**
- * Extract clean retrieval text from a `<function>` markup document: realm,
- * description, and each argument/return as `name (type): desc`. Argument names
- * and types live in XML attributes, so we read them rather than strip — a plain
- * text strip would drop them. Returns null for non-function markup (categories,
- * panels, enums), letting the caller fall back to HTML.
+ * Extract retrieval text from `<function>` markup: realm, description, and
+ * each argument/return as `name (type): desc`. Argument names and types live
+ * in XML attributes, so a plain text-strip would lose them.
+ * Returns null for non-function markup so the caller falls back to HTML.
  */
 function embedTextFromMarkup(markup: string): string | null {
   if (!markup.includes("<function")) return null;
+
   const $ = cheerio.load(markup, { xmlMode: true });
   const fn = $("function").first();
   if (fn.length === 0) return null;
 
   const realm = clean(fn.find("realm").first().text());
   const desc = clean(fn.children("description").first().text());
+
   const args = fn
     .find("args > arg")
     .map((_, el) => `${$(el).attr("name") || ""} (${$(el).attr("type") || ""}): ${clean($(el).text())}`)
     .get();
+
   const rets = fn
     .find("rets > ret")
     .map((_, el) => {
@@ -69,30 +76,33 @@ function embedTextFromMarkup(markup: string): string | null {
 }
 
 /**
- * Build the text we embed for a page: address, title, tag words, then the body.
- * Leading with the address makes the exact API name (e.g. `Player:Say`) a strong
- * retrieval signal. The body comes from the structured markup when available
- * (keeps typed args, drops nav cruft), else falls back to stripped HTML. Capped
- * at {@link MAX_EMBED_CHARS} for the model's window.
+ * Build the text we embed for a page: address, title, tag words, then body.
+ * Leading with the address makes the exact API name (e.g. `Player:Say`) a
+ * strong retrieval signal. The body comes from structured markup when
+ * available (keeps typed args, drops nav cruft), else from stripped HTML.
  */
 export function buildEmbedText(entry: RawEntry): string {
   const tagWords = (entry.tags || "").replace(/[-_]/g, " ").trim();
   const body = (entry.markup && embedTextFromMarkup(entry.markup)) || extractPlainText(entry.html || "");
   const titlePart = entry.title && entry.title !== entry.address ? entry.title : "";
+
   const combined = [entry.address, titlePart, tagWords, body]
     .filter((p) => p && p.length > 0)
     .join(". ")
     .replace(/\s+/g, " ")
     .trim();
+
   return combined.slice(0, MAX_EMBED_CHARS);
 }
 
-// Just the prose <description> from function markup — clean, with no signature,
+// Just the prose <description> from function markup: no signature,
 // "Search Github" link, or "Description" heading that HTML-stripping pulls in.
 function descriptionFromMarkup(markup: string): string | null {
   if (!markup.includes("<function")) return null;
+
   const $ = cheerio.load(markup, { xmlMode: true });
   const desc = clean($("function").first().children("description").first().text());
+
   return desc || null;
 }
 
@@ -102,7 +112,9 @@ function descriptionFromMarkup(markup: string): string | null {
  */
 export function buildSnippet(entry: RawEntry, maxLen = 200): string {
   const body = (entry.markup && descriptionFromMarkup(entry.markup)) || extractPlainText(entry.html || "");
+
   if (body.length <= maxLen) return body;
+
   const cut = body.lastIndexOf(" ", maxLen);
   return body.slice(0, cut > 0 ? cut : maxLen) + "...";
 }

--- a/semantic/core/embed-text.ts
+++ b/semantic/core/embed-text.ts
@@ -1,20 +1,85 @@
 import * as cheerio from "cheerio";
-import type { RawEntry } from "./types.js";
+import type { PageKind, RawEntry } from "./types.js";
 
 const MAX_EMBED_CHARS = 1800;
+
+const FUNCTION_TYPES = new Set(["classfunc", "libraryfunc", "panelfunc"]);
+const HOOK_TYPES = new Set(["hook", "panelhook"]);
+
+/**
+ * Classify a page from its markup `<function type="...">` attribute. Callable
+ * functions and event hooks are distinguished so ranking can prefer functions
+ * for action queries; everything else (enums, structs, categories, panels) is
+ * `other`. Pages without function markup are `other`.
+ */
+export function kindFor(entry: RawEntry): PageKind {
+  const t = entry.markup?.match(/<function[^>]*\btype="([^"]+)"/)?.[1];
+  if (t && FUNCTION_TYPES.has(t)) return "function";
+  if (t && HOOK_TYPES.has(t)) return "hook";
+  return "other";
+}
 
 export function extractPlainText(html: string): string {
   const $ = cheerio.load(html);
   $("script, style").remove();
+  $(".function_links").remove(); // drops the "Search Github" link
   $("br").replaceWith("\n");
   const text = $.root().text();
   return text.replace(/\s+/g, " ").trim();
 }
 
+// Drop markdown links and bare URLs (notes/warnings embed source links that are
+// noise for retrieval), then collapse whitespace.
+function clean(s: string): string {
+  return s
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/https?:\/\/\S+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Extract clean retrieval text from a `<function>` markup document: realm,
+ * description, and each argument/return as `name (type): desc`. Argument names
+ * and types live in XML attributes, so we read them rather than strip — a plain
+ * text strip would drop them. Returns null for non-function markup (categories,
+ * panels, enums), letting the caller fall back to HTML.
+ */
+function embedTextFromMarkup(markup: string): string | null {
+  if (!markup.includes("<function")) return null;
+  const $ = cheerio.load(markup, { xmlMode: true });
+  const fn = $("function").first();
+  if (fn.length === 0) return null;
+
+  const realm = clean(fn.find("realm").first().text());
+  const desc = clean(fn.children("description").first().text());
+  const args = fn
+    .find("args > arg")
+    .map((_, el) => `${$(el).attr("name") || ""} (${$(el).attr("type") || ""}): ${clean($(el).text())}`)
+    .get();
+  const rets = fn
+    .find("rets > ret")
+    .map((_, el) => {
+      const name = $(el).attr("name");
+      return `returns ${$(el).attr("type") || ""}${name ? " " + name : ""}: ${clean($(el).text())}`;
+    })
+    .get();
+
+  return [realm, desc, ...args, ...rets].filter(Boolean).join(". ");
+}
+
+/**
+ * Build the text we embed for a page: address, title, tag words, then the body.
+ * Leading with the address makes the exact API name (e.g. `Player:Say`) a strong
+ * retrieval signal. The body comes from the structured markup when available
+ * (keeps typed args, drops nav cruft), else falls back to stripped HTML. Capped
+ * at {@link MAX_EMBED_CHARS} for the model's window.
+ */
 export function buildEmbedText(entry: RawEntry): string {
   const tagWords = (entry.tags || "").replace(/[-_]/g, " ").trim();
-  const body = extractPlainText(entry.html || "");
-  const combined = [entry.title, tagWords, body]
+  const body = (entry.markup && embedTextFromMarkup(entry.markup)) || extractPlainText(entry.html || "");
+  const titlePart = entry.title && entry.title !== entry.address ? entry.title : "";
+  const combined = [entry.address, titlePart, tagWords, body]
     .filter((p) => p && p.length > 0)
     .join(". ")
     .replace(/\s+/g, " ")
@@ -22,8 +87,21 @@ export function buildEmbedText(entry: RawEntry): string {
   return combined.slice(0, MAX_EMBED_CHARS);
 }
 
+// Just the prose <description> from function markup — clean, with no signature,
+// "Search Github" link, or "Description" heading that HTML-stripping pulls in.
+function descriptionFromMarkup(markup: string): string | null {
+  if (!markup.includes("<function")) return null;
+  const $ = cheerio.load(markup, { xmlMode: true });
+  const desc = clean($("function").first().children("description").first().text());
+  return desc || null;
+}
+
+/**
+ * Short preview shown under a search result. Prefers the markup description
+ * (clean prose) and falls back to stripped HTML for non-function pages.
+ */
 export function buildSnippet(entry: RawEntry, maxLen = 200): string {
-  const body = extractPlainText(entry.html || "");
+  const body = (entry.markup && descriptionFromMarkup(entry.markup)) || extractPlainText(entry.html || "");
   if (body.length <= maxLen) return body;
   const cut = body.lastIndexOf(" ", maxLen);
   return body.slice(0, cut > 0 ? cut : maxLen) + "...";

--- a/semantic/core/highlight.test.ts
+++ b/semantic/core/highlight.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { highlightTerms } from "./highlight.js";
+
+describe("highlightTerms", () => {
+  it("marks matching terms", () => {
+    const runs = highlightTerms("Forces the player to say text", "player say");
+    const matched = runs.filter((r) => r.match).map((r) => r.text.toLowerCase());
+    expect(matched).toContain("player");
+    expect(matched).toContain("say");
+  });
+  it("returns a single unmatched run when nothing matches", () => {
+    const runs = highlightTerms("Forces the bot to talk", "networking");
+    expect(runs).toEqual([{ text: "Forces the bot to talk", match: false }]);
+  });
+});

--- a/semantic/core/highlight.ts
+++ b/semantic/core/highlight.ts
@@ -1,0 +1,32 @@
+export function highlightTerms(
+  snippet: string,
+  query: string,
+): { text: string; match: boolean }[] {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.replace(/[^a-z0-9_:.-]/gi, ""))
+    .filter((t) => t.length >= 2);
+
+  if (terms.length === 0) return [{ text: snippet, match: false }];
+
+  const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const re = new RegExp(`(${escaped.join("|")})`, "gi");
+
+  const runs: { text: string; match: boolean }[] = [];
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(snippet)) !== null) {
+    if (m.index > lastIndex) {
+      runs.push({ text: snippet.slice(lastIndex, m.index), match: false });
+    }
+    runs.push({ text: m[0], match: true });
+    lastIndex = m.index + m[0].length;
+    if (m.index === re.lastIndex) re.lastIndex++; // guard against zero-length matches
+  }
+  if (lastIndex < snippet.length) {
+    runs.push({ text: snippet.slice(lastIndex), match: false });
+  }
+  if (runs.length === 0) return [{ text: snippet, match: false }];
+  return runs;
+}

--- a/semantic/core/hybrid.test.ts
+++ b/semantic/core/hybrid.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { hybridSearch } from "./search.js";
+import type { SearchResult } from "./types.js";
+
+const semanticResults: SearchResult[] = [
+  { address: "Player:Say", title: "Player:Say", url: "/Player:Say", snippet: "say", score: 0.9, source: "semantic" },
+  { address: "Concept:Chat", title: "Concept:Chat", url: "/Concept:Chat", snippet: "chat", score: 0.7, source: "semantic" },
+];
+const keywordResults = [{ id: "Player:Say", snippet: "player to say" }, { id: "Entity:Fire", snippet: "fire" }];
+const meta = (id: string) => ({ title: id, url: "/" + id, snippet: id });
+
+describe("hybridSearch", () => {
+  it("fuses both retrievers and marks shared hits as 'both'", async () => {
+    const out = await hybridSearch("player say", 10, {
+      semantic: async () => semanticResults,
+      keyword: () => keywordResults,
+      meta,
+    });
+    const top = out.find((r) => r.address === "Player:Say")!;
+    expect(top.source).toBe("both");
+    expect(out[0].address).toBe("Player:Say"); // found by both -> highest fused score
+    expect(out.map((r) => r.address)).toEqual(expect.arrayContaining(["Concept:Chat", "Entity:Fire"]));
+  });
+});

--- a/semantic/core/keyword.test.ts
+++ b/semantic/core/keyword.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { keywordRank } from "./keyword.js";
+
+const index = {
+  player: [["Player:Say", "forces the player to say"], ["Entity:GetOwner", "the player who owns"]],
+  say: [["Player:Say", "player to say text"]],
+};
+
+describe("keywordRank", () => {
+  it("ranks pages matching more query terms higher", () => {
+    const out = keywordRank(index, "player say", 10);
+    expect(out[0].id).toBe("Player:Say"); // matches both terms
+    expect(out.map((o) => o.id)).toContain("Entity:GetOwner");
+  });
+});

--- a/semantic/core/keyword.ts
+++ b/semantic/core/keyword.ts
@@ -1,0 +1,23 @@
+export function keywordRank(
+  index: Record<string, string[][]>,
+  query: string,
+  limit: number,
+): { id: string; snippet: string }[] {
+  const terms = query.toLowerCase().split(/\s+/).filter((t) => t.length >= 2);
+  const hits = new Map<string, { count: number; snippet: string }>();
+
+  for (const term of terms) {
+    const entries = index[term];
+    if (!entries) continue;
+    for (const [path, context] of entries) {
+      const existing = hits.get(path);
+      if (existing) existing.count += 1;
+      else hits.set(path, { count: 1, snippet: context });
+    }
+  }
+
+  return [...hits.entries()]
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, limit)
+    .map(([id, v]) => ({ id, snippet: v.snippet }));
+}

--- a/semantic/core/model.test.ts
+++ b/semantic/core/model.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { MODEL_ID, EMBEDDING_DIMS, RRF_K } from "./model.js";
+
+describe("model constants", () => {
+  it("pins the bge-base model and its dimensions", () => {
+    expect(MODEL_ID).toBe("@cf/baai/bge-base-en-v1.5");
+    expect(EMBEDDING_DIMS).toBe(768);
+    expect(RRF_K).toBe(60);
+  });
+});

--- a/semantic/core/model.ts
+++ b/semantic/core/model.ts
@@ -1,3 +1,5 @@
+import type { PageKind } from "./types.js";
+
 export const MODEL_ID = "@cf/baai/bge-base-en-v1.5";
 export const EMBEDDING_DIMS = 768;
 // Standard RRF dampening constant (Cormack et al. 2009).
@@ -6,3 +8,15 @@ export const RRF_K = 60;
 // passages (no prefix), queries MUST carry this instruction. Both embedder
 // adapters apply it so hosted and offline surfaces rank identically.
 export const QUERY_PREFIX = "Represent this sentence for searching relevant passages: ";
+
+// Event hooks phrase their docs in user-intent language ("Called when a player
+// sends a chat message"), so they out-rank the function you'd actually call for
+// an action query. Gently demote them: a clearly-better function wins, but hooks
+// stay fully reachable. This is the one knob to tune — raise toward 1 for a
+// lighter touch, lower for a stronger preference for functions.
+export const HOOK_RANK_PENALTY = 0.9;
+
+/** Score multiplier applied to a result given its {@link PageKind}. */
+export function kindWeight(kind?: PageKind): number {
+  return kind === "hook" ? HOOK_RANK_PENALTY : 1;
+}

--- a/semantic/core/model.ts
+++ b/semantic/core/model.ts
@@ -1,0 +1,8 @@
+export const MODEL_ID = "@cf/baai/bge-base-en-v1.5";
+export const EMBEDDING_DIMS = 768;
+// Standard RRF dampening constant (Cormack et al. 2009).
+export const RRF_K = 60;
+// bge-base-en-v1.5 is an asymmetric retrieval model: documents are embedded as
+// passages (no prefix), queries MUST carry this instruction. Both embedder
+// adapters apply it so hosted and offline surfaces rank identically.
+export const QUERY_PREFIX = "Represent this sentence for searching relevant passages: ";

--- a/semantic/core/page.ts
+++ b/semantic/core/page.ts
@@ -1,0 +1,25 @@
+/**
+ * Convert a page's rendered HTML into clean text for `get_page`. The HTML
+ * already carries everything an LLM needs (signature, typed args, returns,
+ * example code) — it just needs readable spacing, so we turn block-level
+ * boundaries into newlines before stripping tags. No DOM deps, so it bundles
+ * safely into the Cloudflare Worker.
+ */
+export function pageToContent(html: string): string {
+  return (html || "")
+    .replace(/<\/(p|div|h[1-6]|li|tr|pre|section|article)>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    // Decode the entities that appear in signatures/code examples — otherwise the
+    // LLM sees `&amp;`/`&quot;` instead of `&`/`"`. (&amp; last to avoid re-decoding.)
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&#x27;/gi, "'")
+    .replace(/&amp;/gi, "&")
+    .replace(/[^\S\n]+/g, " ") // collapse spaces/tabs, keep newlines
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/semantic/core/rrf.test.ts
+++ b/semantic/core/rrf.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { reciprocalRankFusion } from "./rrf.js";
+
+describe("reciprocalRankFusion", () => {
+  it("ranks an item found by both lists above items found by one", () => {
+    const keyword = ["a", "b", "c"];
+    const semantic = ["b", "d", "e"];
+    const fused = reciprocalRankFusion([keyword, semantic]);
+    expect(fused[0].id).toBe("b");
+    expect(fused.find((f) => f.id === "b")!.sources).toEqual([0, 1]);
+  });
+  it("includes items unique to a single list", () => {
+    const fused = reciprocalRankFusion([["a"], ["z"]]);
+    expect(fused.map((f) => f.id).sort()).toEqual(["a", "z"]);
+  });
+});

--- a/semantic/core/rrf.ts
+++ b/semantic/core/rrf.ts
@@ -1,0 +1,23 @@
+import { RRF_K } from "./model.js";
+
+export function reciprocalRankFusion(
+  lists: string[][],
+  k: number = RRF_K,
+): { id: string; score: number; sources: number[] }[] {
+  const scores = new Map<string, { score: number; sources: number[] }>();
+  lists.forEach((list, listIndex) => {
+    list.forEach((id, rank) => {
+      const contribution = 1 / (k + rank + 1);
+      const existing = scores.get(id);
+      if (existing) {
+        existing.score += contribution;
+        existing.sources.push(listIndex);
+      } else {
+        scores.set(id, { score: contribution, sources: [listIndex] });
+      }
+    });
+  });
+  return [...scores.entries()]
+    .map(([id, v]) => ({ id, score: v.score, sources: v.sources }))
+    .sort((a, b) => b.score - a.score);
+}

--- a/semantic/core/search.test.ts
+++ b/semantic/core/search.test.ts
@@ -13,4 +13,36 @@ describe("semanticSearch", () => {
     expect(results[0].score).toBeCloseTo(0.91, 5);
     expect(results).toHaveLength(2);
   });
+
+  it("demotes a hook below a slightly-lower-scoring function (type-aware nudge)", async () => {
+    // Hook out-scores the function on raw cosine, but the penalty flips them.
+    const hookFirst = {
+      async query() {
+        return [{ id: "GM:PlayerSay", score: 0.8 }, { id: "Player:Say", score: 0.75 }];
+      },
+    };
+    const kindMeta = (id: string) => ({
+      title: id,
+      url: "/" + id,
+      snippet: "",
+      kind: (id.startsWith("GM:") ? "hook" : "function") as "hook" | "function",
+    });
+    const results = await semanticSearch("send a chat message", 2, { embedder, store: hookFirst, meta: kindMeta });
+    expect(results.map((r) => r.address)).toEqual(["Player:Say", "GM:PlayerSay"]);
+    expect(results[0].kind).toBe("function");
+  });
+
+  it("leaves a hook on top when it wins by more than the penalty", async () => {
+    const bigGap = {
+      async query() {
+        return [{ id: "GM:PlayerSay", score: 0.9 }, { id: "Player:Say", score: 0.5 }];
+      },
+    };
+    const kindMeta = (id: string) => ({
+      title: id, url: "/" + id, snippet: "",
+      kind: (id.startsWith("GM:") ? "hook" : "function") as "hook" | "function",
+    });
+    const results = await semanticSearch("hook called when a player chats", 2, { embedder, store: bigGap, meta: kindMeta });
+    expect(results[0].address).toBe("GM:PlayerSay");
+  });
 });

--- a/semantic/core/search.test.ts
+++ b/semantic/core/search.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { semanticSearch } from "./search.js";
+import { EMBEDDING_DIMS } from "./model.js";
+
+const embedder = { async embed() { const v = new Float32Array(EMBEDDING_DIMS); v[0] = 1; return v; } };
+const store = { async query() { return [{ id: "Player:Say", score: 0.91 }, { id: "Entity:Fire", score: 0.5 }]; } };
+const meta = (id: string) => ({ title: id, url: "/" + id, snippet: id + " snippet" });
+
+describe("semanticSearch", () => {
+  it("maps store matches to SearchResults with source=semantic", async () => {
+    const results = await semanticSearch("how to make a player talk", 2, { embedder, store, meta });
+    expect(results[0]).toMatchObject({ address: "Player:Say", source: "semantic", url: "/Player:Say" });
+    expect(results[0].score).toBeCloseTo(0.91, 5);
+    expect(results).toHaveLength(2);
+  });
+});

--- a/semantic/core/search.ts
+++ b/semantic/core/search.ts
@@ -1,0 +1,72 @@
+import type { Embedder, VectorStore, SearchResult, PageGetter } from "./types.js";
+import { reciprocalRankFusion } from "./rrf.js";
+
+export async function semanticSearch(
+  query: string,
+  k: number,
+  deps: {
+    embedder: Embedder;
+    store: VectorStore;
+    meta: (id: string) => { title: string; url: string; snippet: string } | null;
+  },
+): Promise<SearchResult[]> {
+  const vector = await deps.embedder.embed(query);
+  const matches = await deps.store.query(vector, k);
+  const out: SearchResult[] = [];
+  for (const m of matches) {
+    const meta = m.metadata ?? deps.meta(m.id);
+    if (!meta) continue;
+    out.push({
+      address: m.id,
+      title: meta.title,
+      url: meta.url,
+      snippet: meta.snippet,
+      score: m.score,
+      source: "semantic",
+    });
+  }
+  return out;
+}
+
+export async function hybridSearch(
+  query: string,
+  k: number,
+  deps: {
+    semantic: () => Promise<SearchResult[]>;
+    keyword: () => { id: string; snippet: string }[];
+    meta: (id: string) => { title: string; url: string; snippet: string } | null;
+  },
+): Promise<SearchResult[]> {
+  const [semantic, keyword] = [await deps.semantic(), deps.keyword()];
+
+  const semanticIds = semantic.map((r) => r.address);
+  const keywordIds = keyword.map((r) => r.id);
+  const fused = reciprocalRankFusion([keywordIds, semanticIds]); // list 0 = keyword, 1 = semantic
+
+  const snippetById = new Map<string, string>();
+  for (const r of semantic) snippetById.set(r.address, r.snippet);
+  for (const r of keyword) if (!snippetById.has(r.id)) snippetById.set(r.id, r.snippet);
+
+  // Semantic results carry real title/url (from Vectorize on the hosted path, or
+  // the manifest offline). Prefer them over the meta() fallback, which on the
+  // hosted path is only a placeholder (the Worker has no manifest to look up).
+  const metaById = new Map<string, { title: string; url: string; snippet: string }>();
+  for (const r of semantic) metaById.set(r.address, { title: r.title, url: r.url, snippet: r.snippet });
+
+  const out: SearchResult[] = [];
+  for (const f of fused.slice(0, k)) {
+    const meta = metaById.get(f.id) ?? deps.meta(f.id);
+    const inKeyword = f.sources.includes(0);
+    const inSemantic = f.sources.includes(1);
+    const source: SearchResult["source"] = inKeyword && inSemantic ? "both" : inSemantic ? "semantic" : "keyword";
+    out.push({
+      address: f.id,
+      title: meta?.title ?? f.id,
+      url: meta?.url ?? "/" + f.id,
+      snippet: snippetById.get(f.id) ?? meta?.snippet ?? "",
+      score: f.score,
+      source,
+    });
+  }
+  return out;
+}

--- a/semantic/core/search.ts
+++ b/semantic/core/search.ts
@@ -1,5 +1,8 @@
-import type { Embedder, VectorStore, SearchResult, PageGetter } from "./types.js";
+import type { Embedder, VectorStore, SearchResult, PageGetter, PageKind } from "./types.js";
 import { reciprocalRankFusion } from "./rrf.js";
+import { kindWeight } from "./model.js";
+
+type Meta = { title: string; url: string; snippet: string; kind?: PageKind };
 
 export async function semanticSearch(
   query: string,
@@ -7,7 +10,7 @@ export async function semanticSearch(
   deps: {
     embedder: Embedder;
     store: VectorStore;
-    meta: (id: string) => { title: string; url: string; snippet: string } | null;
+    meta: (id: string) => Meta | null;
   },
 ): Promise<SearchResult[]> {
   const vector = await deps.embedder.embed(query);
@@ -21,10 +24,14 @@ export async function semanticSearch(
       title: meta.title,
       url: meta.url,
       snippet: meta.snippet,
-      score: m.score,
+      kind: meta.kind,
+      // Type-aware nudge: demote hooks so the function you'd actually call wins
+      // a near-tie. Re-sorted below so the order reflects the adjusted score.
+      score: m.score * kindWeight(meta.kind),
       source: "semantic",
     });
   }
+  out.sort((a, b) => b.score - a.score);
   return out;
 }
 
@@ -34,7 +41,7 @@ export async function hybridSearch(
   deps: {
     semantic: () => Promise<SearchResult[]>;
     keyword: () => { id: string; snippet: string }[];
-    meta: (id: string) => { title: string; url: string; snippet: string } | null;
+    meta: (id: string) => Meta | null;
   },
 ): Promise<SearchResult[]> {
   const [semantic, keyword] = [await deps.semantic(), deps.keyword()];
@@ -48,10 +55,11 @@ export async function hybridSearch(
   for (const r of keyword) if (!snippetById.has(r.id)) snippetById.set(r.id, r.snippet);
 
   // Semantic results carry real title/url (from Vectorize on the hosted path, or
-  // the manifest offline). Prefer them over the meta() fallback, which on the
-  // hosted path is only a placeholder (the Worker has no manifest to look up).
-  const metaById = new Map<string, { title: string; url: string; snippet: string }>();
-  for (const r of semantic) metaById.set(r.address, { title: r.title, url: r.url, snippet: r.snippet });
+  // the manifest offline) plus the type-aware nudge already applied to their
+  // ordering. Prefer them over the meta() fallback, which on the hosted path is
+  // only a placeholder (the Worker has no manifest to look up).
+  const metaById = new Map<string, Meta>();
+  for (const r of semantic) metaById.set(r.address, { title: r.title, url: r.url, snippet: r.snippet, kind: r.kind });
 
   const out: SearchResult[] = [];
   for (const f of fused.slice(0, k)) {
@@ -64,6 +72,7 @@ export async function hybridSearch(
       title: meta?.title ?? f.id,
       url: meta?.url ?? "/" + f.id,
       snippet: snippetById.get(f.id) ?? meta?.snippet ?? "",
+      kind: meta?.kind,
       score: f.score,
       source,
     });

--- a/semantic/core/tools.ts
+++ b/semantic/core/tools.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import type { PageGetter, SearchResult } from "./types.js";
+
+// Server-level instructions surfaced to the LLM at connection time (MCP
+// `initialize` result). Tells the model what this server is and how to drive it.
+export const SERVER_INSTRUCTIONS = `Semantic search over the Garry's Mod Lua API wiki (gmodwiki.com), a mirror of Facepunch's official GMod developer documentation.
+
+Use this to answer questions about GMod Lua scripting — functions, hooks, classes, methods, enums, structs, and libraries.
+
+Workflow:
+1. Call \`search_wiki\` with a natural-language description of what you're trying to do (e.g. "make a player take damage") to discover relevant pages.
+2. Each result has an \`address\` — pass it to \`get_page\` to read the full documentation (arguments, return values, examples).
+
+Page addresses look like: \`Player:Say\` (a method on the Player class), \`Global.print\` (a global function), \`GM:PlayerSpawn\` (a gamemode hook), \`Entity\` (a class), or \`ENUM_NAME\` (an enum). Prefer searching to find the right address rather than guessing it.`;
+
+// Works with both @modelcontextprotocol/sdk's McpServer and Cloudflare's McpServer:
+// both expose .tool(name, description, zodShape, handler).
+export function registerTools(
+  server: { tool: (name: string, description: string, schema: any, handler: any) => void },
+  deps: {
+    search: (query: string, k: number) => Promise<SearchResult[]>;
+    getPage: PageGetter;
+  },
+): void {
+  server.tool(
+    "search_wiki",
+    "Semantically search the Garry's Mod Lua API wiki for functions, hooks, classes, methods, enums, and libraries. Best with a natural-language description of the task (e.g. \"make a player say something in chat\"). Returns ranked pages, each with an `address` (pass to get_page for full docs), `title`, `url`, and a `snippet`.",
+    {
+      query: z.string().describe("Natural-language description of what you want to do, or a keyword (e.g. 'damage a player', 'PlayerSpawn hook')"),
+      k: z.number().min(1).max(50).default(8).describe("Number of results to return"),
+    },
+    async ({ query, k }: { query: string; k: number }) => {
+      const results = await deps.search(query, k);
+      return {
+        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    "get_page",
+    "Fetch the full documentation text for a Garry's Mod wiki page by its address (arguments, return values, description, examples). Get the address from search_wiki results.",
+    { address: z.string().describe("Page address from a search_wiki result, e.g. 'Player:Say', 'Global.print', 'GM:PlayerSpawn'") },
+    async ({ address }: { address: string }) => {
+      const page = await deps.getPage(address);
+      if (!page) {
+        return { content: [{ type: "text", text: `No page found for '${address}'` }], isError: true };
+      }
+      return { content: [{ type: "text", text: `# ${page.title}\n\n${page.content}` }] };
+    },
+  );
+}

--- a/semantic/core/tools.ts
+++ b/semantic/core/tools.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 import type { PageGetter, SearchResult } from "./types.js";
 
-// Server-level instructions surfaced to the LLM at connection time (MCP
-// `initialize` result). Tells the model what this server is and how to drive it.
 export const SERVER_INSTRUCTIONS = `Semantic search over the Garry's Mod Lua API wiki (gmodwiki.com), a mirror of Facepunch's official GMod developer documentation.
 
 Use this to answer questions about GMod Lua scripting — functions, hooks, classes, methods, enums, structs, and libraries.
@@ -13,8 +11,6 @@ Workflow:
 
 Page addresses look like: \`Player:Say\` (a method on the Player class), \`Global.print\` (a global function), \`GM:PlayerSpawn\` (a gamemode hook), \`Entity\` (a class), or \`ENUM_NAME\` (an enum). Prefer searching to find the right address rather than guessing it.`;
 
-// Works with both @modelcontextprotocol/sdk's McpServer and Cloudflare's McpServer:
-// both expose .tool(name, description, zodShape, handler).
 export function registerTools(
   server: { tool: (name: string, description: string, schema: any, handler: any) => void },
   deps: {

--- a/semantic/core/tools.ts
+++ b/semantic/core/tools.ts
@@ -3,11 +3,11 @@ import type { PageGetter, SearchResult } from "./types.js";
 
 export const SERVER_INSTRUCTIONS = `Semantic search over the Garry's Mod Lua API wiki (gmodwiki.com), a mirror of Facepunch's official GMod developer documentation.
 
-Use this to answer questions about GMod Lua scripting — functions, hooks, classes, methods, enums, structs, and libraries.
+Use this to answer questions about GMod Lua scripting: functions, hooks, classes, methods, enums, structs, and libraries.
 
 Workflow:
 1. Call \`search_wiki\` with a natural-language description of what you're trying to do (e.g. "make a player take damage") to discover relevant pages.
-2. Each result has an \`address\` — pass it to \`get_page\` to read the full documentation (arguments, return values, examples).
+2. Each result has an \`address\`: pass it to \`get_page\` to read the full documentation (arguments, return values, examples).
 
 Page addresses look like: \`Player:Say\` (a method on the Player class), \`Global.print\` (a global function), \`GM:PlayerSpawn\` (a gamemode hook), \`Entity\` (a class), or \`ENUM_NAME\` (an enum). Prefer searching to find the right address rather than guessing it.`;
 
@@ -42,7 +42,8 @@ export function registerTools(
       if (!page) {
         return { content: [{ type: "text", text: `No page found for '${address}'` }], isError: true };
       }
-      return { content: [{ type: "text", text: `# ${page.title}\n\n${page.content}` }] };
+      const url = `https://gmodwiki.com/${address}`;
+      return { content: [{ type: "text", text: `# ${page.title}\n\n${page.content}\n\nSource: ${url}` }] };
     },
   );
 }

--- a/semantic/core/types.ts
+++ b/semantic/core/types.ts
@@ -1,0 +1,51 @@
+export interface RawEntry {
+  address: string;
+  title: string;
+  tags: string;
+  markup?: string;
+  html: string;
+  revisionId?: number;
+}
+
+export interface ManifestEntry {
+  id: string;        // == address; the Vectorize vector id
+  address: string;
+  title: string;
+  snippet: string;   // short plain-text preview for results
+  url: string;       // "/<address>"
+  changeKey: string; // revisionId as string, or a content hash fallback
+}
+
+export interface Manifest {
+  model: string;
+  dims: number;
+  count: number;
+  entries: ManifestEntry[]; // index i corresponds to vector i in embeddings.bin
+}
+
+export interface Match {
+  id: string;   // address
+  score: number;
+  metadata?: { title: string; url: string; snippet: string };
+}
+
+export interface SearchResult {
+  address: string;
+  title: string;
+  url: string;
+  snippet: string;
+  score: number;
+  source: "keyword" | "semantic" | "both";
+}
+
+export interface Embedder {
+  embed(text: string): Promise<Float32Array>;
+}
+
+export interface VectorStore {
+  query(vector: Float32Array, k: number): Promise<Match[]>;
+}
+
+export type PageGetter = (
+  address: string,
+) => Promise<{ title: string; content: string } | null>;

--- a/semantic/core/types.ts
+++ b/semantic/core/types.ts
@@ -1,51 +1,103 @@
+/**
+ * Coarse page category used to nudge ranking. Action queries ("damage a
+ * player") almost always want the `function` you call, not the `hook` that
+ * fires — so hooks get a gentle rank penalty (see `kindWeight`).
+ */
+export type PageKind = "function" | "hook" | "other";
+
+/**
+ * A wiki page as loaded from the build cache, before embedding. The raw inputs
+ * to {@link Manifest} generation.
+ */
 export interface RawEntry {
+  /** Page address, e.g. `Player:Say`. Doubles as the Vectorize vector id. */
   address: string;
+  /** Human-readable title; often equal to {@link RawEntry.address}. */
   title: string;
+  /** Space-separated tag words, e.g. `function method realm-server`. */
   tags: string;
+  /** Facepunch wiki source markup (XML-ish). Absent for some category pages. */
   markup?: string;
+  /** Rendered HTML of the page body. */
   html: string;
+  /** Wiki revision id; used as the change key for incremental rebuilds. */
   revisionId?: number;
 }
 
+/**
+ * One row of {@link Manifest}. Carries everything needed to render a search
+ * result without touching the page content, plus the key used to decide whether
+ * a page needs re-embedding.
+ */
 export interface ManifestEntry {
-  id: string;        // == address; the Vectorize vector id
+  /** Equals {@link ManifestEntry.address}; the Vectorize vector id. */
+  id: string;
   address: string;
   title: string;
-  snippet: string;   // short plain-text preview for results
-  url: string;       // "/<address>"
-  changeKey: string; // revisionId as string, or a content hash fallback
+  /** Short plain-text preview shown under a result. */
+  snippet: string;
+  /** Site-relative URL, `"/<address>"`. */
+  url: string;
+  /** Coarse page category, used for type-aware rank nudging. */
+  kind: PageKind;
+  /** revisionId (version-prefixed), or a content hash when no revisionId. Equal keys ⇒ unchanged. */
+  changeKey: string;
 }
 
+/**
+ * The sidecar index for `embeddings.bin`. Entry `i` describes the vector stored
+ * at row `i` of the binary — the two are kept in lockstep.
+ */
 export interface Manifest {
+  /** Embedding model id, e.g. `@cf/baai/bge-base-en-v1.5`. */
   model: string;
+  /** Vector dimensionality (768 for bge-base). */
   dims: number;
+  /** Number of entries/vectors. */
   count: number;
-  entries: ManifestEntry[]; // index i corresponds to vector i in embeddings.bin
+  /** Entry `i` corresponds to vector `i` in `embeddings.bin`. */
+  entries: ManifestEntry[];
 }
 
+/** A single nearest-neighbour hit returned by a {@link VectorStore}. */
 export interface Match {
-  id: string;   // address
+  /** The page address. */
+  id: string;
+  /** Similarity score (cosine); higher is closer. */
   score: number;
-  metadata?: { title: string; url: string; snippet: string };
+  /** Result metadata when the store carries it (e.g. Vectorize); else undefined. */
+  metadata?: { title: string; url: string; snippet: string; kind?: PageKind };
 }
 
+/** A ranked result surfaced to a user or assistant. */
 export interface SearchResult {
   address: string;
   title: string;
   url: string;
   snippet: string;
+  /** Coarse page category (function/hook/other), when known. */
+  kind?: PageKind;
+  /** Fused relevance score. */
   score: number;
+  /** Which retriever(s) produced this: keyword-only, semantic-only, or both. */
   source: "keyword" | "semantic" | "both";
 }
 
+/** Turns query text into a normalized embedding vector. */
 export interface Embedder {
   embed(text: string): Promise<Float32Array>;
 }
 
+/** Nearest-neighbour search over stored embeddings. */
 export interface VectorStore {
+  /** Return the top-`k` matches for `vector`. */
   query(vector: Float32Array, k: number): Promise<Match[]>;
 }
 
+/**
+ * Fetches a page's title and LLM-ready body text by address, or `null` if the
+ * page does not exist. Backed by the local content dir or the live site.
+ */
 export type PageGetter = (
   address: string,
 ) => Promise<{ title: string; content: string } | null>;

--- a/semantic/mcp/hosted/package-lock.json
+++ b/semantic/mcp/hosted/package-lock.json
@@ -1,0 +1,3295 @@
+{
+  "name": "gmodwiki-mcp-hosted",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gmodwiki-mcp-hosted",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "agents": "^0.2.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20251229.0",
+        "wrangler": "^4.47.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260625.1.tgz",
+      "integrity": "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260625.1.tgz",
+      "integrity": "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260625.1.tgz",
+      "integrity": "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260629.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260629.1.tgz",
+      "integrity": "sha512-5vq2ErIFVRSQ8Dcw5YOeEoBdZBudqBjHFKTWD3SBGiJR5hD1+/86aRUV/DTpEK9sXXCGOTGgpWBGlPSlW7djVg==",
+      "license": "MIT OR Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agents": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.2.35.tgz",
+      "integrity": "sha512-e6Ift6X0sFceYgFBIZGK4jQ+vyFq9caSF80ilsAVHzfFHvqb21013UrgGzZac4X+fzAP103YBSgS7C57tjAj8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@modelcontextprotocol/sdk": "1.23.0",
+        "cron-schedule": "^6.0.0",
+        "json-schema": "^0.4.0",
+        "json-schema-to-typescript": "^15.0.4",
+        "mimetext": "^3.0.27",
+        "nanoid": "^5.1.6",
+        "partyserver": "^0.1.0",
+        "partysocket": "1.1.10",
+        "yargs": "^18.0.0",
+        "zod-to-ts": "^2.0.0"
+      },
+      "bin": {
+        "agents": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@ai-sdk/openai": ">=2.0.0",
+        "@ai-sdk/react": ">=1.0.0",
+        "ai": ">=5.0.0",
+        "react": "^19.0.0",
+        "viem": ">=2.0.0",
+        "x402": "^0.7.1",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/openai": {
+          "optional": true
+        },
+        "@ai-sdk/react": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        },
+        "x402": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agents/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.23.0.tgz",
+      "integrity": "sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/agents/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cron-schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-6.0.0.tgz",
+      "integrity": "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimetext": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
+      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@babel/runtime-corejs3": "^7.26.0",
+        "js-base64": "^3.7.7",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260625.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
+      "integrity": "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260625.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/partyserver": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.1.5.tgz",
+      "integrity": "sha512-kaE3GYaYWFc70EJQDQEhyYbO2Wczz/NgsFXerfjRo0t2s7ZxL1XggWT+HkMrdEyqbZOv3b66CV93WG0Lcg/ThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20240729.0"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.10.tgz",
+      "integrity": "sha512-ACfn0P6lQuj8/AqB4L5ZDFcIEbpnIteNNObrlxqV1Ge80GTGhjuJ2sNKwNQlFzhGi4kI7fP/C1Eqh8TR78HjDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.3.tgz",
+      "integrity": "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260625.1.tgz",
+      "integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260625.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260625.1",
+        "@cloudflare/workerd-linux-64": "1.20260625.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260625.1",
+        "@cloudflare/workerd-windows-64": "1.20260625.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.105.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
+      "integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260625.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260625.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260625.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zod-to-ts": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-2.1.0.tgz",
+      "integrity": "sha512-jZP1GokTqR99FLmtGU+B9acjD9u/R++b++Vxe1sWpBQDd82/9/j5LyLZZ7/Oy3h2nxcz5NihikgX4D0hhdu3+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6",
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    }
+  }
+}

--- a/semantic/mcp/hosted/package.json
+++ b/semantic/mcp/hosted/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "gmodwiki-mcp-hosted",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "agents": "^0.2.0",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "wrangler": "^4.47.0",
+    "@cloudflare/workers-types": "^4.20251229.0"
+  }
+}

--- a/semantic/mcp/hosted/src/empty.ts
+++ b/semantic/mcp/hosted/src/empty.ts
@@ -1,0 +1,6 @@
+// Stub module aliased to "ai" in wrangler.toml.
+// The agents package has a dynamic import("ai") in its MCP-client code path
+// (used only when McpAgent acts as an MCP *client* calling generateText).
+// This worker is a pure MCP *server* and never reaches that code path,
+// so it is safe to stub the "ai" module out entirely at bundle time.
+export {};

--- a/semantic/mcp/hosted/src/index.ts
+++ b/semantic/mcp/hosted/src/index.ts
@@ -1,0 +1,54 @@
+import { McpAgent } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools, SERVER_INSTRUCTIONS } from "../../../core/tools.js";
+import { semanticSearch } from "../../../core/search.js";
+import { HostedEmbedder } from "../../../adapters/hosted/embedder.js";
+import { HostedVectorStore } from "../../../adapters/hosted/store.js";
+import type { SearchResult } from "../../../core/types.js";
+
+interface Env {
+  AI: Ai;
+  VECTORIZE: VectorizeIndex;
+}
+
+export class GmodWikiMCP extends McpAgent<Env> {
+  server = new McpServer({ name: "gmodwiki", version: "1.0.0" }, { instructions: SERVER_INSTRUCTIONS });
+
+  async init() {
+    const embedder = new HostedEmbedder(this.env.AI);
+    const store = new HostedVectorStore(this.env.VECTORIZE);
+
+    const search = (query: string, k: number): Promise<SearchResult[]> =>
+      semanticSearch(query, k, {
+        embedder,
+        store,
+        // Vectorize returns metadata; we re-query for it inside the store if needed.
+        // Here we fetch metadata directly from the match via a thin wrapper:
+        meta: (id) => ({ title: id, url: "/" + id, snippet: "" }),
+      });
+
+    const getPage = async (address: string) => {
+      const res = await fetch(`https://gmodwiki.com/content/${address.toLowerCase()}.json`);
+      if (!res.ok) return null;
+      const page: any = await res.json();
+      // page.html is processed HTML; strip to text for the assistant.
+      const text = page.html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+      return { title: page.title, content: text };
+    };
+
+    registerTools(this.server, { search, getPage });
+  }
+}
+
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+    if (url.pathname === "/sse" || url.pathname === "/sse/message") {
+      return GmodWikiMCP.serveSSE("/sse").fetch(request, env, ctx);
+    }
+    if (url.pathname === "/mcp") {
+      return GmodWikiMCP.serve("/mcp").fetch(request, env, ctx);
+    }
+    return new Response("gmodwiki MCP server. Connect via /mcp or /sse.", { status: 200 });
+  },
+};

--- a/semantic/mcp/hosted/src/index.ts
+++ b/semantic/mcp/hosted/src/index.ts
@@ -1,6 +1,7 @@
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerTools, SERVER_INSTRUCTIONS } from "../../../core/tools.js";
+import { pageToContent } from "../../../core/page.js";
 import { semanticSearch } from "../../../core/search.js";
 import { HostedEmbedder } from "../../../adapters/hosted/embedder.js";
 import { HostedVectorStore } from "../../../adapters/hosted/store.js";
@@ -31,9 +32,7 @@ export class GmodWikiMCP extends McpAgent<Env> {
       const res = await fetch(`https://gmodwiki.com/content/${address.toLowerCase()}.json`);
       if (!res.ok) return null;
       const page: any = await res.json();
-      // page.html is processed HTML; strip to text for the assistant.
-      const text = page.html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
-      return { title: page.title, content: text };
+      return { title: page.title, content: pageToContent(page.html) };
     };
 
     registerTools(this.server, { search, getPage });

--- a/semantic/mcp/hosted/wrangler.toml
+++ b/semantic/mcp/hosted/wrangler.toml
@@ -1,0 +1,24 @@
+name = "gmodwiki-mcp"
+main = "src/index.ts"
+compatibility_date = "2025-10-08"
+compatibility_flags = ["nodejs_compat"]
+
+# The agents package has a dynamic import("ai") in its MCP-client path.
+# This worker is a pure MCP server and never hits that path, so we stub
+# "ai" with an empty module to avoid a bundle error.
+[alias]
+ai = "./src/empty.ts"
+
+[ai]
+binding = "AI"
+
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "gmodwiki-embeddings"
+
+[durable_objects]
+bindings = [{ name = "MCP_OBJECT", class_name = "GmodWikiMCP" }]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["GmodWikiMCP"]

--- a/semantic/mcp/local/index.ts
+++ b/semantic/mcp/local/index.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { promises as fs } from "fs";
 import path from "path";
 import { registerTools, SERVER_INSTRUCTIONS } from "../../core/tools.js";
+import { pageToContent } from "../../core/page.js";
 import { semanticSearch } from "../../core/search.js";
 import { LocalEmbedder } from "../../adapters/local/embedder.js";
 import { LocalVectorStore } from "../../adapters/local/store.js";
@@ -23,8 +24,7 @@ async function main() {
     try {
       const raw = await fs.readFile(path.join(CONTENT_DIR, `${address.toLowerCase()}.json`), "utf8");
       const page: any = JSON.parse(raw);
-      const text = page.html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
-      return { title: page.title, content: text };
+      return { title: page.title, content: pageToContent(page.html) };
     } catch {
       return null;
     }

--- a/semantic/mcp/local/index.ts
+++ b/semantic/mcp/local/index.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { promises as fs } from "fs";
+import path from "path";
+import { registerTools, SERVER_INSTRUCTIONS } from "../../core/tools.js";
+import { semanticSearch } from "../../core/search.js";
+import { LocalEmbedder } from "../../adapters/local/embedder.js";
+import { LocalVectorStore } from "../../adapters/local/store.js";
+
+const BIN = process.env.EMBEDDINGS_BIN ?? "./public/embeddings.bin";
+const MANIFEST = process.env.EMBEDDINGS_MANIFEST ?? "./public/embeddings_manifest.json";
+const CONTENT_DIR = process.env.CONTENT_DIR ?? "./public/content";
+
+async function main() {
+  const embedder = new LocalEmbedder();
+  const store = await LocalVectorStore.load(BIN, MANIFEST);
+
+  const search = (query: string, k: number) =>
+    semanticSearch(query, k, { embedder, store, meta: (id) => store.meta(id) });
+
+  const getPage = async (address: string) => {
+    try {
+      const raw = await fs.readFile(path.join(CONTENT_DIR, `${address.toLowerCase()}.json`), "utf8");
+      const page: any = JSON.parse(raw);
+      const text = page.html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+      return { title: page.title, content: text };
+    } catch {
+      return null;
+    }
+  };
+
+  const server = new McpServer({ name: "gmodwiki", version: "1.0.0" }, { instructions: SERVER_INSTRUCTIONS });
+  registerTools(server, { search, getPage });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("gmodwiki MCP (local) ready");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/semantic/mcp/local/package-lock.json
+++ b/semantic/mcp/local/package-lock.json
@@ -1,0 +1,2171 @@
+{
+  "name": "gmodwiki-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gmodwiki-mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@huggingface/transformers": "^3",
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "gmodwiki-mcp": "index.js"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/semantic/mcp/local/package.json
+++ b/semantic/mcp/local/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "gmodwiki-mcp",
+  "version": "1.0.0",
+  "type": "module",
+  "bin": { "gmodwiki-mcp": "index.js" },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@huggingface/transformers": "^3",
+    "zod": "^3.23.0"
+  }
+}

--- a/semantic/mcp/plugin/.claude-plugin/plugin.json
+++ b/semantic/mcp/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "gmodwiki",
+  "version": "1.0.0",
+  "description": "Semantic search over the Garry's Mod Lua API wiki (gmodwiki.com). Adds the search_wiki and get_page MCP tools so assistants can look up GMod functions, hooks, classes, and examples.",
+  "author": {
+    "name": "CFC-Servers",
+    "url": "https://github.com/CFC-Servers"
+  },
+  "homepage": "https://gmodwiki.com",
+  "repository": "https://github.com/CFC-Servers/gmodwiki"
+}

--- a/semantic/mcp/plugin/.mcp.json
+++ b/semantic/mcp/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gmodwiki": {
+      "type": "http",
+      "url": "https://mcp.gmodwiki.com/mcp"
+    }
+  }
+}

--- a/src/pages/websearch.astro
+++ b/src/pages/websearch.astro
@@ -1,42 +1,41 @@
 ---
 import Layout from "@layouts/Layout.astro";
+import { highlightTerms } from "../../semantic/core/highlight.js";
 
-async function getSearchResults(query: string): Promise<string[][]> {
-    const url = `${Astro.url.protocol}//${Astro.url.host}/websearch.json?query=${query}`;
-
-    const response = await fetch(url);
-    const data: string[][] = await response.json();
-    return data;
+interface SearchResult {
+  address: string; title: string; url: string; snippet: string; score: number;
+  source: "keyword" | "semantic" | "both";
 }
 
 const query = Astro.url.searchParams.get("query") || "";
-const response: string[][] = await getSearchResults(query)
-
-const formatted = response.map((result) => {
-    const href = result[0]
-    const context = result[1]
-    const index = context.toLowerCase().indexOf(query.toLowerCase())
-
-    const pre = context.substring(0, index)
-    const match = context.substring(index, index + query.length)
-    const post = context.substring(index + query.length)
-
-    return {
-        page: href,
-        pre: pre,
-        match: match,
-        post: post
-    }
-})
-
+const endpoint = `${Astro.url.protocol}//${Astro.url.host}/websearch.json?query=${encodeURIComponent(query)}`;
+const results: SearchResult[] = await (await fetch(endpoint)).json();
 ---
 
 <Layout title="Search Results" description="Garry's Mod Wiki" views="" updated="">
-    <h2>Searching for: "{query}"</h2>
-    {formatted.map((result) => (
-        <div class="section">
-            <h3> <a href=`/${result.page}`>{result.page}</a> </h3>
-            <div> {result.pre} <span class="highlight">{result.match}</span> {result.post} </div>
-        </div>
-    ))}
+  <h2>Searching for: "{query}"</h2>
+  {results.length === 0 && <p>No results found.</p>}
+  {results.map((result) => (
+    <div class="section">
+      <h3>
+        <a href={result.url}>{result.title}</a>
+        <span class="search-source" data-source={result.source}>{result.source}</span>
+      </h3>
+      <div>
+        {highlightTerms(result.snippet, query).map((run) =>
+          run.match ? <span class="highlight">{run.text}</span> : <span>{run.text}</span>,
+        )}
+      </div>
+    </div>
+  ))}
 </Layout>
+
+<style>
+  .search-source {
+    font-size: 0.7em;
+    opacity: 0.6;
+    margin-left: 0.5em;
+    text-transform: uppercase;
+  }
+  .highlight { font-weight: 700; }
+</style>

--- a/src/pages/websearch.json.ts
+++ b/src/pages/websearch.json.ts
@@ -1,21 +1,80 @@
-import type { APIRoute } from 'astro'
+import type { APIRoute } from "astro";
+import { hybridSearch, semanticSearch } from "../../semantic/core/search.js";
+import { keywordRank } from "../../semantic/core/keyword.js";
+import { HostedEmbedder } from "../../semantic/adapters/hosted/embedder.js";
+import { HostedVectorStore } from "../../semantic/adapters/hosted/store.js";
 
-export const GET: APIRoute = async ({ params, request }) => {
-    const url = new URL(request.url)
+// Local adapter lazy loaders — dynamic imports so transformers.js/onnxruntime-node
+// are never pulled into the Cloudflare Worker bundle.
+let localStorePromise: Promise<any> | null = null;
+let localEmbedder: any = null;
 
-    const query = url.searchParams.get("query")
-    if (!query || query.length == 0) return new Response("No query provided", { status: 400 })
-    const normalized = query.toLowerCase()
-
-    const domain = url.host
-    let indexUrl = `${url.origin}/search_index.json`
-    if (domain === "gmodwiki.com") {
-        indexUrl = "https://storage.gmodwiki.com/search_index.json"
-    }
-
-    const response = await fetch(indexUrl)
-    const index: any = await response.json()
-
-    const results = index[normalized]
-    return new Response(JSON.stringify(results || []));
+async function getLocalDeps() {
+  const { LocalVectorStore } = await import("../../semantic/adapters/local/store.js");
+  const { LocalEmbedder } = await import("../../semantic/adapters/local/embedder.js");
+  if (!localStorePromise) {
+    // EMBEDDINGS_BIN / EMBEDDINGS_MANIFEST allow the Docker final image to point
+    // at dist/client/ (where Astro copies public/ assets) instead of the source
+    // public/ tree which is not present in the container.
+    const binPath = process.env.EMBEDDINGS_BIN ?? "./public/embeddings.bin";
+    const manifestPath = process.env.EMBEDDINGS_MANIFEST ?? "./public/embeddings_manifest.json";
+    localStorePromise = LocalVectorStore.load(binPath, manifestPath);
+  }
+  if (!localEmbedder) localEmbedder = new LocalEmbedder();
+  return { store: await localStorePromise, embedder: localEmbedder };
 }
+
+export const GET: APIRoute = async ({ url, locals, request }) => {
+  const query = url.searchParams.get("query");
+  if (!query || query.length === 0) return new Response("No query provided", { status: 400 });
+
+  const host = url.host;
+  const indexUrl = host === "gmodwiki.com"
+    ? "https://storage.gmodwiki.com/search_index.json"
+    : `${url.origin}/search_index.json`;
+  const keywordIndex = await (await fetch(indexUrl)).json() as Record<string, string[][]>;
+
+  const env = (locals as any)?.runtime?.env;
+
+  // Hosted path: Workers AI + Vectorize available as bindings.
+  if (env?.AI && env?.VECTORIZE) {
+    try {
+      const embedder = new HostedEmbedder(env.AI);
+      const store = new HostedVectorStore(env.VECTORIZE);
+      const results = await hybridSearch(query, 50, {
+        semantic: () =>
+          semanticSearch(query, 50, {
+            embedder,
+            store,
+            meta: (id) => ({ title: id, url: "/" + id, snippet: "" }),
+          }),
+        keyword: () => keywordRank(keywordIndex, query, 50),
+        meta: (id) => ({ title: id, url: "/" + id, snippet: "" }),
+      });
+      return new Response(JSON.stringify(results), { headers: { "content-type": "application/json" } });
+    } catch (e) {
+      // Transient Workers AI / Vectorize error — degrade to keyword-only below
+      // rather than 500ing, since the keyword index is already in hand.
+      console.warn("hosted semantic search unavailable, falling back to keyword:", e);
+    }
+  }
+
+  // Offline path (Node adapter / Docker): local model + on-disk vectors, if the artifact exists.
+  try {
+    const { store, embedder } = await getLocalDeps();
+    const results = await hybridSearch(query, 50, {
+      semantic: () => semanticSearch(query, 50, { embedder, store, meta: (id: string) => store.meta(id) }),
+      keyword: () => keywordRank(keywordIndex, query, 50),
+      meta: (id: string) => store.meta(id),
+    });
+    return new Response(JSON.stringify(results), { headers: { "content-type": "application/json" } });
+  } catch (e) {
+    console.warn("local semantic search unavailable, falling back to keyword:", e);
+  }
+
+  // Fallback (no bindings, e.g. local Node before Phase 3): keyword-only, shaped as SearchResult[].
+  const keywordOnly = keywordRank(keywordIndex, query, 50).map((r) => ({
+    address: r.id, title: r.id, url: "/" + r.id, snippet: r.snippet, score: 0, source: "keyword" as const,
+  }));
+  return new Response(JSON.stringify(keywordOnly), { headers: { "content-type": "application/json" } });
+};

--- a/src/pages/websearch.json.ts
+++ b/src/pages/websearch.json.ts
@@ -4,8 +4,6 @@ import { keywordRank } from "../../semantic/core/keyword.js";
 import { HostedEmbedder } from "../../semantic/adapters/hosted/embedder.js";
 import { HostedVectorStore } from "../../semantic/adapters/hosted/store.js";
 
-// Local adapter lazy loaders — dynamic imports so transformers.js/onnxruntime-node
-// are never pulled into the Cloudflare Worker bundle.
 let localStorePromise: Promise<any> | null = null;
 let localEmbedder: any = null;
 
@@ -13,9 +11,6 @@ async function getLocalDeps() {
   const { LocalVectorStore } = await import("../../semantic/adapters/local/store.js");
   const { LocalEmbedder } = await import("../../semantic/adapters/local/embedder.js");
   if (!localStorePromise) {
-    // EMBEDDINGS_BIN / EMBEDDINGS_MANIFEST allow the Docker final image to point
-    // at dist/client/ (where Astro copies public/ assets) instead of the source
-    // public/ tree which is not present in the container.
     const binPath = process.env.EMBEDDINGS_BIN ?? "./public/embeddings.bin";
     const manifestPath = process.env.EMBEDDINGS_MANIFEST ?? "./public/embeddings_manifest.json";
     localStorePromise = LocalVectorStore.load(binPath, manifestPath);
@@ -53,13 +48,12 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
       });
       return new Response(JSON.stringify(results), { headers: { "content-type": "application/json" } });
     } catch (e) {
-      // Transient Workers AI / Vectorize error — degrade to keyword-only below
-      // rather than 500ing, since the keyword index is already in hand.
+
       console.warn("hosted semantic search unavailable, falling back to keyword:", e);
     }
   }
 
-  // Offline path (Node adapter / Docker): local model + on-disk vectors, if the artifact exists.
+  // Offline path (Node adapter / Docker): local model + on-disk vectors
   try {
     const { store, embedder } = await getLocalDeps();
     const results = await hybridSearch(query, 50, {
@@ -72,7 +66,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
     console.warn("local semantic search unavailable, falling back to keyword:", e);
   }
 
-  // Fallback (no bindings, e.g. local Node before Phase 3): keyword-only, shaped as SearchResult[].
+  // Fallback (no bindings?): keyword-only
   const keywordOnly = keywordRank(keywordIndex, query, 50).map((r) => ({
     address: r.id, title: r.id, url: "/" + r.id, snippet: r.snippet, score: 0, source: "keyword" as const,
   }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"],
+  "exclude": [
+    "dist",
+    "build/fragments",
+    "semantic/mcp/hosted",
+    "semantic/mcp/local"
+  ],
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["ES2021", "WebWorker"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["semantic/core/**/*.test.ts", "build/**/*.test.ts", "semantic/adapters/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,10 @@
 name = "gmodwiki"
 compatibility_date = "2025-10-08"
 pages_build_output_dir = "./dist"
+
+[ai]
+binding = "AI"
+
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "gmodwiki-embeddings"


### PR DESCRIPTION
Adds a hybrid semantic/keyword full-site search _(i.e. when you hit "enter" in the search bar; live-filtering sidebar behavior remains the same)_, and adds a public MCP server that allows LLMs to search and retrieve info from the wiki.

At build time, we create an embedding (Cloudflare Workers AI) for every wiki page and then pack it into a binary artifact which is then synced to a Cloudflare Vectorize index.

Offline hybrid searching is available, too. We ship the embedding blob and an embedding model with the Docker image (it's small but still inflates the size a bit. I think that's fine.)

On our incremental builds, only pages that change get re-embedded and synced (quick + cheap).

MCP server auto-deploys on merge into `main`.